### PR TITLE
Add metadata validation to campaign creation

### DIFF
--- a/src/CapitalDistributorPlugin.sol
+++ b/src/CapitalDistributorPlugin.sol
@@ -292,6 +292,9 @@ contract CapitalDistributorPlugin is
         returns (uint256 id)
     {
         // Input validation
+        if (_metadataURI.length == 0) {
+            revert EmptyMetadataURI();
+        }
         if (address(_payout.token) == address(0)) {
             revert ZeroAddress("_token");
         }

--- a/tests/CapitalDistributorPluginTest.t.sol
+++ b/tests/CapitalDistributorPluginTest.t.sol
@@ -67,7 +67,7 @@ contract CapitalDistributorPluginTest is AragonTest {
     /// @notice Helper function to create a basic campaign with default parameters
     function createBasicCampaign() internal returns (uint256) {
         return capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -95,7 +95,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         returns (uint256)
     {
         return capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(multipleClaimsAllowed, startTime, endTime)
@@ -113,7 +113,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         returns (uint256)
     {
         return capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(strategyId, "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), encoderId, encoderInitData),
             CapitalDistributorPlugin.CampaignSettings(multipleClaimsAllowed, 0, 0)
@@ -134,7 +134,7 @@ contract CapitalDistributorPluginTest is AragonTest {
     function test_CreateCampaign() public {
         vm.startPrank(address(createdDao));
 
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -206,7 +206,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 startTime = block.timestamp + 1000;
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, startTime, 0)
@@ -227,7 +227,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 endTime = block.timestamp + 2000;
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, endTime)
@@ -247,7 +247,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         vm.expectRevert();
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -262,9 +262,24 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         vm.expectRevert(abi.encodeWithSelector(CapitalDistributorPlugin.ZeroAddress.selector, "_token"));
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(address(0)), bytes32(0), ""), // Zero token address
+            CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
+        );
+
+        vm.stopPrank();
+    }
+
+    /// @notice Test that campaign creation fails with empty metadata URI
+    function test_CreateCampaignFailsWithEmptyMetadata() public {
+        vm.startPrank(address(createdDao));
+
+        vm.expectRevert(CapitalDistributorPlugin.EmptyMetadataURI.selector);
+        capitalDistributorPlugin.createCampaign(
+            "", // Empty metadata
+            CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
+            CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
         );
 
@@ -280,7 +295,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         vm.expectRevert(CapitalDistributorPlugin.InvalidTimeBounds.selector);
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, startTime, endTime)
@@ -295,7 +310,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         vm.expectRevert();
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("non-existent-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -333,7 +348,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 futureStartTime = block.timestamp + 86_400; // 1 day in the future
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, futureStartTime, 0)
@@ -352,7 +367,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 pastEndTime = block.timestamp - 86_400; // 1 day in the past
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, pastEndTime)
@@ -371,14 +386,14 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 initialNumCampaigns = capitalDistributorPlugin.numCampaigns();
 
         uint256 campaignId1 = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
         );
 
         uint256 campaignId2 = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -397,7 +412,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 initialNumCampaigns = capitalDistributorPlugin.numCampaigns();
 
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -406,7 +421,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         assertEq(capitalDistributorPlugin.numCampaigns(), initialNumCampaigns + 1, "numCampaigns should increment");
 
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -424,7 +439,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.startPrank(address(createdDao));
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -499,7 +514,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         for (uint256 i = 0; i < 3; i++) {
             campaignIds[i] = capitalDistributorPlugin.createCampaign(
-                "",
+            "ipfs://mock-campaign-metadata",
                 CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
                 CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
                 CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -518,7 +533,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.startPrank(address(createdDao));
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(
                 IERC20(token),
@@ -539,7 +554,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.startPrank(address(createdDao));
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(
                 IERC20(token), toBytes32("vault-deposit-encoder"), abi.encode(address(vaultToSendTokens))
@@ -553,38 +568,19 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.stopPrank();
     }
 
-    /// @notice Test CampaignCreated event emission with empty metadata
+    /// @notice Test that empty metadata is rejected
     function test_CampaignCreatedEventWithEmptyMetadata() public {
         vm.startPrank(address(createdDao));
 
         bytes memory emptyMetadata = "";
 
-        vm.recordLogs();
-
-        uint256 campaignId = capitalDistributorPlugin.createCampaign(
+        vm.expectRevert(CapitalDistributorPlugin.EmptyMetadataURI.selector);
+        capitalDistributorPlugin.createCampaign(
             emptyMetadata,
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
         );
-
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-
-        // Find the CampaignCreated event (should be the last one)
-        bool eventFound = false;
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (
-                logs[i].topics[0]
-                    == keccak256("CampaignCreated(uint256,bytes,address,address,address,bool,uint256,uint256)")
-            ) {
-                eventFound = true;
-                // Verify the campaign ID matches
-                assertEq(uint256(logs[i].topics[1]), campaignId, "Campaign ID in event should match");
-                break;
-            }
-        }
-
-        assertTrue(eventFound, "CampaignCreated event should be emitted");
 
         vm.stopPrank();
     }
@@ -634,7 +630,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         vm.expectRevert();
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), toBytes32("non-existent-encoder"), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -651,7 +647,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 endTime = block.timestamp + 2000;
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, startTime, endTime)
@@ -674,7 +670,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         vm.expectRevert(CapitalDistributorPlugin.InvalidTimeBounds.selector);
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, sameTime, sameTime)
@@ -690,7 +686,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         bytes memory strategyParams = "strategy-deployment-params";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), strategyParams, ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -709,7 +705,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         bytes memory auxData = "allocation-strategy-aux-data";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", auxData),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -728,7 +724,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         bytes memory encoderAuxData = abi.encode(address(vaultToSendTokens));
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), toBytes32("vault-deposit-encoder"), encoderAuxData),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -748,7 +744,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 maxEndTime = type(uint256).max;
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, maxStartTime, maxEndTime)
@@ -769,7 +765,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         uint256 gasBefore = gasleft();
 
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -791,14 +787,14 @@ contract CapitalDistributorPluginTest is AragonTest {
         MintableERC20 token2 = new MintableERC20();
 
         uint256 campaignId1 = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
         );
 
         uint256 campaignId2 = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token2), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -1437,7 +1433,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.startPrank(address(createdDao));
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(
                 IERC20(token), toBytes32("vault-deposit-encoder"), abi.encode(address(vaultToSendTokens))
@@ -2177,7 +2173,7 @@ contract CapitalDistributorPluginTest is AragonTest {
             abi.encodeWithSelector(CapitalDistributorPlugin.FactoryDeploymentFailed.selector, "AllocatorStrategy")
         );
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("zero-address-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -2207,7 +2203,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         // Try to create campaign - should bubble up the revert
         vm.expectRevert("Deployment failed");
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("reverting-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -2232,7 +2228,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         // The factory will catch the setup failure and wrap it in DeploymentFailed
         vm.expectRevert();
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("failing-strategy"), "", "trigger-failure"),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -2265,7 +2261,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         // Expect revert when trying to create campaign with zero encoder
         vm.expectRevert();
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), toBytes32("zero-encoder"), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -2288,7 +2284,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         // The factory will catch the setup failure and wrap it in DeploymentFailed
         vm.expectRevert();
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), toBytes32("failing-encoder"), "trigger-failure"),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -2535,7 +2531,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.expectRevert(abi.encodeWithSelector(CapitalDistributorPlugin.InvalidToken.selector, address(badToken)));
 
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(
                 IERC20(address(badToken)),
@@ -2557,7 +2553,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         // Should NOT revert when using custom encoder
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(
                 IERC20(address(badToken)),
@@ -2584,7 +2580,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
         // Normal token should pass validation
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(
                 IERC20(address(token)), // Normal ERC20
@@ -2616,7 +2612,7 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.expectRevert(abi.encodeWithSelector(CapitalDistributorPlugin.InvalidToken.selector, address(testToken)));
 
         capitalDistributorPlugin.createCampaign(
-            "",
+            "ipfs://mock-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(toBytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(
                 IERC20(address(testToken)),

--- a/tests/CapitalDistributorPluginTestBasic.t.sol
+++ b/tests/CapitalDistributorPluginTestBasic.t.sol
@@ -45,7 +45,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
     function test_CreateCampaign() public {
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -71,7 +71,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
     function test_CannotCreateCampaignWithoutPermissions() public {
         vm.startPrank(address(alice));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         vm.expectRevert();
@@ -94,7 +94,7 @@ contract CapitalDistributorPluginTest is AragonTest {
     function test_PayoutIsSent() public {
         token.mint(address(createdDao), 1 ether);
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -121,7 +121,7 @@ contract CapitalDistributorPluginTest is AragonTest {
 
     function test_PayoutIsSentToVault() public {
         token.mint(address(createdDao), 1 ether);
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         // Add vault deposit permission to the plugin

--- a/tests/allocatorStrategies/GaugeVoterAllocatorStrategyTest.t.sol
+++ b/tests/allocatorStrategies/GaugeVoterAllocatorStrategyTest.t.sol
@@ -84,7 +84,7 @@ contract GaugeDistributionStrategyTest is AragonTest {
         returns (uint256 campaignId)
     {
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = abi.encode(address(mockGaugeVoter));
         bytes memory allocationCampaignAuxData = abi.encode(_distributionAmount);
 
@@ -159,7 +159,7 @@ contract GaugeDistributionStrategyTest is AragonTest {
     /// @notice Test basic campaign creation works
     function testInitialization() public {
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = abi.encode(address(mockGaugeVoter));
         bytes memory allocationCampaignAuxData = abi.encode(DEFAULT_DISTRIBUTION_AMOUNT);
 
@@ -670,7 +670,7 @@ contract GaugeDistributionStrategyTest is AragonTest {
     function testInvalidDistributionAmount() public {
         // Try to create campaign with zero distribution amount
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = abi.encode(address(mockGaugeVoter));
         bytes memory allocationCampaignAuxData = abi.encode(0); // Zero distribution amount
 

--- a/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
+++ b/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
@@ -145,7 +145,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
 
     function test_CreateCampaign() public {
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -165,7 +165,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
 
     function test_CannotCreateCampaignWithoutPermissions() public {
         vm.startPrank(address(alice));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         vm.expectRevert();
@@ -182,7 +182,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
     function test_PayoutIsSent() public {
         token.mint(address(createdDao), 10 ether);
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -212,7 +212,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
     function test_MultipleRecipientsClaim() public {
         token.mint(address(createdDao), 10 ether);
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -245,7 +245,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
     function test_InvalidProofReverts() public {
         token.mint(address(createdDao), 10 ether);
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -270,7 +270,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
     function test_CannotClaimTwice() public {
         token.mint(address(createdDao), 10 ether);
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -299,7 +299,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
 
     function test_GetCampaignPayout() public {
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -336,7 +336,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         assertNotEq(scriptRoot, bytes32(0), "Script should generate non-zero merkle root");
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -357,7 +357,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 scriptRoot = getScriptGeneratedMerkleRoot();
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -404,7 +404,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 scriptRoot = getScriptGeneratedMerkleRoot();
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -441,7 +441,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
 
         token.mint(address(createdDao), 1000 ether);
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -498,7 +498,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -546,7 +546,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -585,7 +585,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -625,7 +625,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -701,7 +701,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 validRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -734,7 +734,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -770,7 +770,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 firstRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -804,7 +804,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -839,7 +839,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -877,7 +877,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -917,7 +917,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -949,7 +949,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 testRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         // Test event emission during campaign creation
@@ -973,7 +973,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes32 initialRoot = merkleRoot;
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -1053,7 +1053,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         token.mint(address(createdDao), 10 ether);
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
@@ -1094,7 +1094,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         token.mint(address(createdDao), 10 ether);
 
         vm.startPrank(address(createdDao));
-        bytes memory metadata = "";
+        bytes memory metadata = "ipfs://mock-campaign-metadata";
         bytes memory allocatorDeploymentParams = "";
 
         uint256 campaignId = capitalDistributorPlugin.createCampaign(

--- a/tests/integration/ExecuteConditionIntegrationTest.t.sol
+++ b/tests/integration/ExecuteConditionIntegrationTest.t.sol
@@ -94,7 +94,7 @@ contract ExecuteConditionIntegrationTest is Test {
         // Create a campaign
         vm.startPrank(address(dao));
         uint256 campaignId = plugin.createCampaign(
-            "",
+            "ipfs://test-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(bytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(token, bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -117,7 +117,7 @@ contract ExecuteConditionIntegrationTest is Test {
         // Create a campaign
         vm.startPrank(address(dao));
         uint256 campaignId = plugin.createCampaign(
-            "",
+            "ipfs://test-campaign-metadata",
             CapitalDistributorPlugin.StrategyConfig(bytes32("mock-strategy"), "", ""),
             CapitalDistributorPlugin.PayoutConfig(token, bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)


### PR DESCRIPTION
Requires non-empty campaign metadata URIs. Updates test cases to use mock metadata instead of empty strings.