### PR TITLE
Refactor test suite to use in-memory merkle generator

### DIFF
--- a/src/CapitalDistributorPlugin.sol
+++ b/src/CapitalDistributorPlugin.sol
@@ -367,7 +367,7 @@ contract CapitalDistributorPlugin is
     function _validateTokenBehavior(IERC20 _token) internal view {
         // Try to transferFrom address(0) to this plugin
         // This should ALWAYS fail for any legitimate token
-        (bool success, bytes memory data) =
+        (bool success,) =
             address(_token).staticcall(abi.encodeCall(IERC20.transferFrom, (address(0), address(this), 1)));
 
         if (success) {

--- a/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
+++ b/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
@@ -1,31 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.29 <0.9.0;
 
-import { stdJson } from "forge-std/StdJson.sol";
-
 import { CapitalDistributorPlugin } from "../../src/CapitalDistributorPlugin.sol";
 import { AragonTest } from "../helpers/AragonTest.sol";
 import { MerkleDistributorStrategy } from "../../src/allocatorStrategies/MerkleDistributorStrategy.sol";
 
 import { MintableERC20 } from "../mocks/MintableERC20.sol";
+import { MerkleMockGenerator } from "../mocks/MerkleMockGenerator.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
-import { CreateExampleRecipients } from "../../script/utils/CreateExampleRecipients.s.sol";
-import { GenerateMerkleTree } from "../../script/utils/GenerateMerkleTree.s.sol";
-import { GenerateProof } from "../../script/utils/GenerateProof.s.sol";
 import { ExecuteSelectorCondition } from "@aragon/conditions/ExecuteSelectorCondition.sol";
 
 contract MerkleDistributorStrategyTest is AragonTest {
-    using stdJson for string;
-
     CapitalDistributorPlugin capitalDistributorPlugin;
     MerkleDistributorStrategy strategy;
     MintableERC20 token;
     ExecuteSelectorCondition condition;
-
-    // Merkle tree scripts
-    CreateExampleRecipients createExampleScript;
-    GenerateMerkleTree generateTreeScript;
-    GenerateProof generateProofScript;
+    MerkleMockGenerator mockGenerator;
 
     // Merkle tree test data (legacy)
     address[] recipients;
@@ -33,9 +23,9 @@ contract MerkleDistributorStrategyTest is AragonTest {
     bytes32[] leaves;
     bytes32 merkleRoot;
 
-    // Script-generated test data
-    string constant TEST_RECIPIENTS_FILE = "./tests/data/test-recipients-merkle.json";
-    string constant TEST_TREE_FILE = "./tests/data/merkle-tree.json";
+    // Mock-generated test data cached values
+    bytes32 standardMerkleRoot;
+    bytes32 largeMerkleRoot;
 
     /// @dev A function invoked before each test case is run.
     function setUp() public virtual {
@@ -45,10 +35,8 @@ contract MerkleDistributorStrategyTest is AragonTest {
         strategy = new MerkleDistributorStrategy();
         condition = ExecuteSelectorCondition(conditions[0]);
 
-        // Deploy scripts
-        createExampleScript = new CreateExampleRecipients();
-        generateTreeScript = new GenerateMerkleTree();
-        generateProofScript = new GenerateProof();
+        // Deploy mock generator
+        mockGenerator = new MerkleMockGenerator();
 
         vm.startPrank(address(createdDao));
         allocatorStrategyFactory.registerStrategyType(
@@ -65,8 +53,8 @@ contract MerkleDistributorStrategyTest is AragonTest {
         // Set up merkle tree test data (keep legacy for existing tests)
         setupMerkleTreeData();
 
-        // Set up script-generated test data
-        setupScriptGeneratedData();
+        // Set up mock-generated test data
+        setupMockGeneratedData();
     }
 
     function setupMerkleTreeData() internal {
@@ -102,31 +90,37 @@ contract MerkleDistributorStrategyTest is AragonTest {
         return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
     }
 
-    function setupScriptGeneratedData() internal {
-        // Create test recipients using the script
-        createExampleScript.createTestnetExample(TEST_RECIPIENTS_FILE);
+    function setupMockGeneratedData() internal {
+        // Generate and cache merkle roots for standard test data
+        MerkleMockGenerator.MerkleData memory standardData = mockGenerator.generateStandardTestData();
+        standardMerkleRoot = standardData.root;
 
-        // Generate merkle tree using the script
-        generateTreeScript.generate(TEST_RECIPIENTS_FILE);
+        // Generate and cache merkle root for large test data
+        MerkleMockGenerator.MerkleData memory largeData = mockGenerator.generateLargeTestData();
+        largeMerkleRoot = largeData.root;
     }
 
-    function getScriptGeneratedMerkleRoot() internal view returns (bytes32) {
-        string memory treeJson = vm.readFile(TEST_TREE_FILE);
-        return treeJson.readBytes32(".merkleRoot");
+    function getMockGeneratedMerkleRoot() internal view returns (bytes32) {
+        return standardMerkleRoot;
     }
 
-    function getScriptGeneratedProof(address recipient) internal returns (bytes32[] memory, uint256) {
-        // Generate proof using script
-        generateProofScript.generateProof(TEST_TREE_FILE, recipient);
+    function getMockGeneratedProof(address recipient) internal view returns (bytes32[] memory, uint256) {
+        // Re-generate standard test data to find recipient
+        MerkleMockGenerator.MerkleData memory standardData = mockGenerator.generateStandardTestData();
 
-        // Read the generated proof file from test data directory
-        string memory proofFile = string.concat("./tests/data/proof-", vm.toString(recipient), ".json");
-        string memory proofJson = vm.readFile(proofFile);
+        uint256 recipientIndex = type(uint256).max;
+        for (uint256 i = 0; i < standardData.recipients.length; i++) {
+            if (standardData.recipients[i].account == recipient) {
+                recipientIndex = i;
+                break;
+            }
+        }
 
-        // Parse proof data
-        bytes memory proofData = proofJson.parseRaw(".proof");
-        bytes32[] memory proof = abi.decode(proofData, (bytes32[]));
-        uint256 amount = proofJson.readUint(".amount");
+        require(recipientIndex != type(uint256).max, "Recipient not found in test data");
+
+        // Generate proof for the recipient
+        bytes32[] memory proof = mockGenerator.generateProof(standardData, recipientIndex);
+        uint256 amount = standardData.recipients[recipientIndex].amount;
 
         return (proof, amount);
     }
@@ -338,12 +332,12 @@ contract MerkleDistributorStrategyTest is AragonTest {
     }
 
     // ============================================================================
-    // Script-based Tests
+    // Mock-based Tests
     // ============================================================================
 
-    function test_ScriptGeneratedMerkleTree() public {
-        bytes32 scriptRoot = getScriptGeneratedMerkleRoot();
-        assertNotEq(scriptRoot, bytes32(0), "Script should generate non-zero merkle root");
+    function test_MockGeneratedMerkleTree() public {
+        bytes32 mockRoot = getMockGeneratedMerkleRoot();
+        assertNotEq(mockRoot, bytes32(0), "Mock should generate non-zero merkle root");
 
         vm.startPrank(address(createdDao));
         bytes memory metadata = "ipfs://mock-campaign-metadata";
@@ -352,7 +346,7 @@ contract MerkleDistributorStrategyTest is AragonTest {
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
             metadata,
             CapitalDistributorPlugin.StrategyConfig(
-                toBytes32("merkle-strategy"), allocatorDeploymentParams, abi.encode(scriptRoot)
+                toBytes32("merkle-strategy"), allocatorDeploymentParams, abi.encode(mockRoot)
             ),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), metadata),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
@@ -362,9 +356,9 @@ contract MerkleDistributorStrategyTest is AragonTest {
         assertTrue(address(campaign.allocationStrategy) != address(0), "Allocation strategy should be set");
     }
 
-    function test_ScriptGeneratedProofsClaim() public {
+    function test_MockGeneratedProofsClaim() public {
         token.mint(address(createdDao), 100 ether);
-        bytes32 scriptRoot = getScriptGeneratedMerkleRoot();
+        bytes32 mockRoot = getMockGeneratedMerkleRoot();
 
         vm.startPrank(address(createdDao));
         bytes memory metadata = "ipfs://mock-campaign-metadata";
@@ -373,23 +367,23 @@ contract MerkleDistributorStrategyTest is AragonTest {
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
             metadata,
             CapitalDistributorPlugin.StrategyConfig(
-                toBytes32("merkle-strategy"), allocatorDeploymentParams, abi.encode(scriptRoot)
+                toBytes32("merkle-strategy"), allocatorDeploymentParams, abi.encode(mockRoot)
             ),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), metadata),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
         );
         vm.stopPrank();
 
-        // Test claims using script-generated proofs
-        address testRecipient1 = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266; // From testnet example
-        address testRecipient2 = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8; // From testnet example
+        // Test claims using mock-generated proofs
+        address testRecipient1 = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266; // From standard test data
+        address testRecipient2 = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8; // From standard test data
 
         // Get proof for recipient 1
-        (bytes32[] memory proof1, uint256 amount1) = getScriptGeneratedProof(testRecipient1);
+        (bytes32[] memory proof1, uint256 amount1) = getMockGeneratedProof(testRecipient1);
         bytes memory claimData1 = abi.encode(proof1, amount1);
 
         // Get proof for recipient 2
-        (bytes32[] memory proof2, uint256 amount2) = getScriptGeneratedProof(testRecipient2);
+        (bytes32[] memory proof2, uint256 amount2) = getMockGeneratedProof(testRecipient2);
         bytes memory claimData2 = abi.encode(proof2, amount2);
 
         uint256 initialBalance1 = token.balanceOf(testRecipient1);
@@ -410,8 +404,8 @@ contract MerkleDistributorStrategyTest is AragonTest {
         );
     }
 
-    function test_ScriptGeneratedProofValidation() public {
-        bytes32 scriptRoot = getScriptGeneratedMerkleRoot();
+    function test_MockGeneratedProofValidation() public {
+        bytes32 mockRoot = getMockGeneratedMerkleRoot();
 
         vm.startPrank(address(createdDao));
         bytes memory metadata = "ipfs://mock-campaign-metadata";
@@ -420,31 +414,28 @@ contract MerkleDistributorStrategyTest is AragonTest {
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
             metadata,
             CapitalDistributorPlugin.StrategyConfig(
-                toBytes32("merkle-strategy"), allocatorDeploymentParams, abi.encode(scriptRoot)
+                toBytes32("merkle-strategy"), allocatorDeploymentParams, abi.encode(mockRoot)
             ),
             CapitalDistributorPlugin.PayoutConfig(IERC20(token), bytes32(0), metadata),
             CapitalDistributorPlugin.CampaignSettings(false, 0, 0)
         );
         vm.stopPrank();
 
-        // Test that script-generated proofs are valid
+        // Test that mock-generated proofs are valid
         address testRecipient = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
-        (bytes32[] memory proof, uint256 amount) = getScriptGeneratedProof(testRecipient);
+        (bytes32[] memory proof, uint256 amount) = getMockGeneratedProof(testRecipient);
         bytes memory claimData = abi.encode(proof, amount);
 
         uint256 payoutAmount = capitalDistributorPlugin.getCampaignPayout(campaignId, testRecipient, claimData);
-        assertEq(payoutAmount, amount, "Script-generated proof should be valid");
+        assertEq(payoutAmount, amount, "Mock-generated proof should be valid");
         assertGt(payoutAmount, 0, "Payout amount should be greater than 0");
     }
 
-    function test_LargeRecipientSetUsingScripts() public {
-        // Create large recipient set using script
-        createExampleScript.createLargeExample("./tests/data/large-recipients-test.json");
-        generateTreeScript.generate("./tests/data/large-recipients-test.json");
-
-        string memory largeTreeJson = vm.readFile("./tests/data/merkle-tree.json");
-        bytes32 largeRoot = largeTreeJson.readBytes32(".merkleRoot");
-        uint256 totalRecipients = largeTreeJson.readUint(".totalRecipients");
+    function test_LargeRecipientSetUsingMocks() public {
+        // Use mock-generated large recipient set
+        MerkleMockGenerator.MerkleData memory largeData = mockGenerator.generateLargeTestData();
+        bytes32 largeRoot = largeData.root;
+        uint256 totalRecipients = largeData.recipients.length;
 
         assertEq(totalRecipients, 100, "Should have 100 recipients");
         assertNotEq(largeRoot, bytes32(0), "Should generate valid merkle root for large set");
@@ -465,37 +456,29 @@ contract MerkleDistributorStrategyTest is AragonTest {
         vm.stopPrank();
 
         // Test claims for a few recipients from the large set
-        address testAddr1 = address(uint160(uint256(keccak256(abi.encodePacked("recipient", uint256(5))))));
-        address testAddr2 = address(uint160(uint256(keccak256(abi.encodePacked("recipient", uint256(25))))));
+        uint256 testIndex1 = 5;
+        uint256 testIndex2 = 25;
 
-        // Generate proofs using script
-        generateProofScript.generateProof("./tests/data/merkle-tree.json", testAddr1);
-        generateProofScript.generateProof("./tests/data/merkle-tree.json", testAddr2);
+        address testAddr1 = largeData.recipients[testIndex1].account;
+        address testAddr2 = largeData.recipients[testIndex2].account;
+        uint256 amount1 = largeData.recipients[testIndex1].amount;
+        uint256 amount2 = largeData.recipients[testIndex2].amount;
 
-        // Read proof files
-        string memory proof1File = string.concat("./tests/data/proof-", vm.toString(testAddr1), ".json");
-        string memory proof2File = string.concat("./tests/data/proof-", vm.toString(testAddr2), ".json");
+        // Generate proofs using mock
+        bytes32[] memory proof1 = mockGenerator.generateProof(largeData, testIndex1);
+        bytes32[] memory proof2 = mockGenerator.generateProof(largeData, testIndex2);
 
-        string memory proof1Json = vm.readFile(proof1File);
-        string memory proof2Json = vm.readFile(proof2File);
+        // Verify proofs are valid by testing claims
+        bytes memory claimData1 = abi.encode(proof1, amount1);
+        bytes memory claimData2 = abi.encode(proof2, amount2);
 
-        // Verify proofs are valid
-        bool valid1 = proof1Json.readBool(".valid");
-        bool valid2 = proof2Json.readBool(".valid");
-
-        assertTrue(valid1, "Proof for recipient 5 should be valid");
-        assertTrue(valid2, "Proof for recipient 25 should be valid");
-
-        // Test actual claims
-        bytes memory proofData1 = proof1Json.parseRaw(".proof");
-        bytes32[] memory proof1Array = abi.decode(proofData1, (bytes32[]));
-        uint256 amount1 = proof1Json.readUint(".amount");
-
-        bytes memory claimData1 = abi.encode(proof1Array, amount1);
         uint256 payoutAmount1 = capitalDistributorPlugin.getCampaignPayout(campaignId, testAddr1, claimData1);
+        uint256 payoutAmount2 = capitalDistributorPlugin.getCampaignPayout(campaignId, testAddr2, claimData2);
 
-        assertEq(payoutAmount1, amount1, "Payout should match script-generated amount");
-        assertGt(payoutAmount1, 0, "Should be able to claim from large recipient set");
+        assertEq(payoutAmount1, amount1, "Payout should match mock-generated amount for recipient 5");
+        assertEq(payoutAmount2, amount2, "Payout should match mock-generated amount for recipient 25");
+        assertEq(payoutAmount1, 6 ether, "Recipient 5 should have 6 ETH (index + 1)");
+        assertEq(payoutAmount2, 26 ether, "Recipient 25 should have 26 ETH (index + 1)");
     }
 
     // ============================================================================
@@ -906,18 +889,20 @@ contract MerkleDistributorStrategyTest is AragonTest {
         vm.stopPrank();
 
         // Verify that the strategy has the correct plugin address stored
-        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(address(campaign.allocationStrategy));
-        assertEq(strategy.plugin(), address(capitalDistributorPlugin), "Plugin address should be stored correctly");
+        MerkleDistributorStrategy allocationStrategy = MerkleDistributorStrategy(address(campaign.allocationStrategy));
+        assertEq(
+            allocationStrategy.plugin(), address(capitalDistributorPlugin), "Plugin address should be stored correctly"
+        );
 
         // Test that updateCampaignMerkleRoot works when called by DAO (using stored plugin address)
         bytes32 newRoot = keccak256("new-root");
         bytes memory newRootData = abi.encode(newRoot);
 
         vm.prank(address(createdDao));
-        strategy.updateCampaignMerkleRoot(campaignId, newRootData);
+        allocationStrategy.updateCampaignMerkleRoot(campaignId, newRootData);
 
         // Verify the root was updated
-        bytes32 updatedRoot = strategy.getCampaignMerkleRoot(campaignId);
+        bytes32 updatedRoot = allocationStrategy.getCampaignMerkleRoot(campaignId);
         assertEq(updatedRoot, newRoot, "Merkle root should be updated");
     }
 

--- a/tests/mocks/MerkleMockGenerator.sol
+++ b/tests/mocks/MerkleMockGenerator.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.19;
+
+/**
+ * @title MerkleMockGenerator
+ * @notice Generates merkle tree data in-memory for testing without file dependencies
+ * @dev Provides the same merkle root and proof generation as the scripts but without file I/O
+ */
+contract MerkleMockGenerator {
+    struct Recipient {
+        address account;
+        uint256 amount;
+    }
+
+    struct MerkleData {
+        bytes32 root;
+        bytes32[] leaves;
+        uint256 totalAmount;
+        Recipient[] recipients;
+    }
+
+    /**
+     * @notice Generate merkle data for standard test set (10 recipients)
+     * @return data The complete merkle tree data
+     */
+    function generateStandardTestData() external pure returns (MerkleData memory data) {
+        data.recipients = new Recipient[](10);
+        data.recipients[0] = Recipient(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, 1 ether);
+        data.recipients[1] = Recipient(0x70997970C51812dc3A010C7d01b50e0d17dc79C8, 2 ether);
+        data.recipients[2] = Recipient(0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC, 3 ether);
+        data.recipients[3] = Recipient(0x90F79bf6EB2c4f870365E785982E1f101E93b906, 4 ether);
+        data.recipients[4] = Recipient(0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65, 5 ether);
+        data.recipients[5] = Recipient(0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc, 6 ether);
+        data.recipients[6] = Recipient(0x976EA74026E726554dB657fA54763abd0C3a0aa9, 7 ether);
+        data.recipients[7] = Recipient(0x14dC79964da2C08b23698B3D3cc7Ca32193d9955, 8 ether);
+        data.recipients[8] = Recipient(0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f, 9 ether);
+        data.recipients[9] = Recipient(0xa0Ee7A142d267C1f36714E4a8F75612F20a79720, 10 ether);
+
+        data = _generateMerkleData(data.recipients);
+    }
+
+    /**
+     * @notice Generate merkle data for large test set (100 recipients)
+     * @return data The complete merkle tree data
+     */
+    function generateLargeTestData() external pure returns (MerkleData memory data) {
+        data.recipients = new Recipient[](100);
+
+        for (uint256 i = 0; i < 100; i++) {
+            address addr = address(uint160(uint256(keccak256(abi.encodePacked("recipient", i)))));
+            uint256 amount = (i + 1) * 1 ether;
+            data.recipients[i] = Recipient(addr, amount);
+        }
+
+        data = _generateMerkleData(data.recipients);
+    }
+
+    /**
+     * @notice Generate merkle proof for a specific recipient
+     * @param merkleData The complete merkle tree data
+     * @param recipientIndex Index of the recipient in the array
+     * @return proof The merkle proof for the recipient
+     */
+    function generateProof(
+        MerkleData memory merkleData,
+        uint256 recipientIndex
+    )
+        external
+        pure
+        returns (bytes32[] memory proof)
+    {
+        require(recipientIndex < merkleData.recipients.length, "Invalid recipient index");
+
+        uint256 leavesLen = merkleData.leaves.length;
+        uint256 pathLength = _log2(leavesLen) + 1;
+        proof = new bytes32[](pathLength);
+        uint256 proofIndex = 0;
+
+        // Build the merkle proof
+        bytes32[] memory currentLevel = merkleData.leaves;
+        uint256 index = recipientIndex;
+
+        while (currentLevel.length > 1) {
+            uint256 pairIndex = index % 2 == 0 ? index + 1 : index - 1;
+
+            if (pairIndex < currentLevel.length) {
+                proof[proofIndex] = currentLevel[pairIndex];
+                proofIndex++;
+            }
+
+            // Move to next level
+            currentLevel = _buildNextLevel(currentLevel);
+            index = index / 2;
+        }
+
+        // Resize proof array
+        bytes32[] memory resizedProof = new bytes32[](proofIndex);
+        for (uint256 i = 0; i < proofIndex; i++) {
+            resizedProof[i] = proof[i];
+        }
+
+        return resizedProof;
+    }
+
+    /**
+     * @notice Internal function to generate merkle data from recipients
+     * @param recipients Array of recipients
+     * @return data The complete merkle tree data
+     */
+    function _generateMerkleData(Recipient[] memory recipients) private pure returns (MerkleData memory data) {
+        data.recipients = new Recipient[](recipients.length);
+        data.leaves = new bytes32[](recipients.length);
+
+        // Copy recipients and generate leaves
+        for (uint256 i = 0; i < recipients.length; i++) {
+            data.recipients[i] = recipients[i];
+            data.leaves[i] = keccak256(abi.encodePacked(recipients[i].account, recipients[i].amount));
+            data.totalAmount += recipients[i].amount;
+        }
+
+        // Build merkle tree
+        data.root = _buildMerkleTree(data.leaves);
+
+        return data;
+    }
+
+    /**
+     * @notice Build merkle tree from leaves
+     * @param leaves Array of leaf hashes
+     * @return root Merkle root hash
+     */
+    function _buildMerkleTree(bytes32[] memory leaves) private pure returns (bytes32) {
+        require(leaves.length > 0, "No leaves provided");
+
+        if (leaves.length == 1) {
+            return leaves[0];
+        }
+
+        bytes32[] memory currentLevel = leaves;
+
+        while (currentLevel.length > 1) {
+            currentLevel = _buildNextLevel(currentLevel);
+        }
+
+        return currentLevel[0];
+    }
+
+    /**
+     * @notice Build next level of merkle tree
+     * @param currentLevel Current level of hashes
+     * @return nextLevel Next level of hashes
+     */
+    function _buildNextLevel(bytes32[] memory currentLevel) private pure returns (bytes32[] memory) {
+        uint256 nextLevelLength = (currentLevel.length + 1) / 2;
+        bytes32[] memory nextLevel = new bytes32[](nextLevelLength);
+
+        for (uint256 i = 0; i < nextLevelLength; i++) {
+            bytes32 left = currentLevel[i * 2];
+
+            if (i * 2 + 1 < currentLevel.length) {
+                bytes32 right = currentLevel[i * 2 + 1];
+                nextLevel[i] =
+                    left < right ? keccak256(abi.encodePacked(left, right)) : keccak256(abi.encodePacked(right, left));
+            } else {
+                nextLevel[i] = left;
+            }
+        }
+
+        return nextLevel;
+    }
+
+    /**
+     * @notice Calculate log2 of a number
+     * @param x The number
+     * @return The log2 of x
+     */
+    function _log2(uint256 x) private pure returns (uint256) {
+        uint256 result = 0;
+        while (x > 1) {
+            x >>= 1;
+            result++;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This moves merkle tree generation from file-based scripts to an in-memory mock generator, reducing test dependencies and improving reliability.