### PR TITLE
Add strategy and encoder permissions to plugin setup

### DIFF
--- a/src/CapitalDistributorPlugin.sol
+++ b/src/CapitalDistributorPlugin.sol
@@ -313,8 +313,9 @@ contract CapitalDistributorPlugin is
 
         // Deploy and setup allocation strategy
         {
-            address strategyAddress =
-                allocatorStrategyFactory.getOrDeployStrategy(_strategy.strategyId, dao(), _strategy.strategyParams);
+            address strategyAddress = allocatorStrategyFactory.getOrDeployStrategy(
+                _strategy.strategyId, dao(), address(this), _strategy.strategyParams
+            );
             if (strategyAddress == address(0)) {
                 revert FactoryDeploymentFailed("AllocatorStrategy");
             }
@@ -331,7 +332,7 @@ contract CapitalDistributorPlugin is
         // Setup action encoder if provided
         if (_payout.actionEncoderId != bytes32(0)) {
             IPayoutActionEncoder actionEncoder = actionEncoderFactory.getOrDeployActionEncoder(
-                _payout.actionEncoderId, dao(), _payout.actionEncoderInitData
+                _payout.actionEncoderId, dao(), address(this), _payout.actionEncoderInitData
             );
             campaign.actionEncoder = actionEncoder;
 

--- a/src/CapitalDistributorPluginSetup.sol
+++ b/src/CapitalDistributorPluginSetup.sol
@@ -26,6 +26,11 @@ contract CapitalDistributorPluginSetup is PluginUpgradeableSetup {
     bytes32 public constant CAMPAIGN_MANAGER_PERMISSION_ID = keccak256("CAMPAIGN_MANAGER_PERMISSION");
     bytes32 public constant SET_METADATA_PERMISSION_ID = keccak256("SET_METADATA_PERMISSION");
     bytes32 public constant MANAGE_SELECTORS_PERMISSION_ID = keccak256("MANAGE_SELECTORS_PERMISSION");
+    bytes32 public constant STRATEGY_MANAGER_PERMISSION_ID = keccak256("STRATEGY_MANAGER_PERMISSION");
+    bytes32 public constant ENCODER_MANAGER_PERMISSION_ID = keccak256("ENCODER_MANAGER_PERMISSION");
+
+    /// @notice A special address encoding permissions that are valid for any address `who` or `where`.
+    address private constant ANY_ADDR = address(type(uint160).max);
 
     /// @notice The address of the `CapitalDistributorPlugin` base contract.
     CapitalDistributorPlugin private immutable CAPITAL_DISTRIBUTOR_PLUGIN_BASE;
@@ -73,7 +78,7 @@ contract CapitalDistributorPluginSetup is PluginUpgradeableSetup {
         );
 
         // Prepare permissions
-        PermissionLib.MultiTargetPermission[] memory permissions = new PermissionLib.MultiTargetPermission[](5);
+        PermissionLib.MultiTargetPermission[] memory permissions = new PermissionLib.MultiTargetPermission[](9);
 
         // Request the permissions to be granted
 
@@ -121,6 +126,42 @@ contract CapitalDistributorPluginSetup is PluginUpgradeableSetup {
             permissionId: MANAGE_SELECTORS_PERMISSION_ID
         });
 
+        // The DAO can manage the encoders
+        permissions[5] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Grant,
+            where: ANY_ADDR,
+            who: _dao,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: ENCODER_MANAGER_PERMISSION_ID
+        });
+
+        // The DAO can manage the strategies
+        permissions[6] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Grant,
+            where: ANY_ADDR,
+            who: _dao,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: STRATEGY_MANAGER_PERMISSION_ID
+        });
+
+        // The plugin can manage the encoders
+        permissions[7] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Grant,
+            where: ANY_ADDR,
+            who: plugin,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: ENCODER_MANAGER_PERMISSION_ID
+        });
+
+        // The plugin can manage the strategies
+        permissions[8] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Grant,
+            where: ANY_ADDR,
+            who: plugin,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: STRATEGY_MANAGER_PERMISSION_ID
+        });
+
         preparedSetupData.helpers = helpers;
         preparedSetupData.permissions = permissions;
     }
@@ -143,7 +184,7 @@ contract CapitalDistributorPluginSetup is PluginUpgradeableSetup {
         address executeCondition = _payload.currentHelpers[0];
 
         // Set permissions to be Revoked.
-        permissions = new PermissionLib.MultiTargetPermission[](5);
+        permissions = new PermissionLib.MultiTargetPermission[](9);
 
         permissions[0] = PermissionLib.MultiTargetPermission({
             operation: PermissionLib.Operation.Revoke,
@@ -183,6 +224,42 @@ contract CapitalDistributorPluginSetup is PluginUpgradeableSetup {
             who: _dao,
             condition: PermissionLib.NO_CONDITION,
             permissionId: MANAGE_SELECTORS_PERMISSION_ID
+        });
+
+        // The DAO can manage the encoders
+        permissions[5] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Revoke,
+            where: ANY_ADDR,
+            who: _dao,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: ENCODER_MANAGER_PERMISSION_ID
+        });
+
+        // The DAO can manage the strategies
+        permissions[6] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Revoke,
+            where: ANY_ADDR,
+            who: _dao,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: STRATEGY_MANAGER_PERMISSION_ID
+        });
+
+        // The plugin can manage the encoders
+        permissions[7] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Revoke,
+            where: ANY_ADDR,
+            who: _payload.plugin,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: ENCODER_MANAGER_PERMISSION_ID
+        });
+
+        // The plugin can manage the strategies
+        permissions[8] = PermissionLib.MultiTargetPermission({
+            operation: PermissionLib.Operation.Revoke,
+            where: ANY_ADDR,
+            who: _payload.plugin,
+            condition: PermissionLib.NO_CONDITION,
+            permissionId: STRATEGY_MANAGER_PERMISSION_ID
         });
     }
 

--- a/src/allocatorStrategies/AllocatorStrategyBase.sol
+++ b/src/allocatorStrategies/AllocatorStrategyBase.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.29;
 import { IAllocatorStrategy } from "../interfaces/IAllocatorStrategy.sol";
 import { IAllocatorStrategyFactory } from "../interfaces/IAllocatorStrategyFactory.sol";
 import { DaoAuthorizableUpgradeable } from "@aragon/commons/permission/auth/DaoAuthorizableUpgradeable.sol";
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { IDAO } from "@aragon/commons/dao/IDAO.sol";
@@ -13,15 +12,12 @@ import { IDAO } from "@aragon/commons/dao/IDAO.sol";
 /// @notice Base contract implementing the IAllocatorStrategy interface.
 /// @dev Provides common functionality for allocation strategies. Implementing contracts should override
 /// abstract functions to define specific allocation logic.
-abstract contract AllocatorStrategyBase is
-    IAllocatorStrategy,
-    DaoAuthorizableUpgradeable,
-    OwnableUpgradeable,
-    ERC165Upgradeable
-{
+abstract contract AllocatorStrategyBase is IAllocatorStrategy, DaoAuthorizableUpgradeable, ERC165Upgradeable {
     bytes32 public strategyId;
     address public plugin;
     address public factory;
+
+    bytes32 public constant STRATEGY_MANAGER_PERMISSION_ID = keccak256("STRATEGY_MANAGER_PERMISSION");
 
     // =========================================================================
     // Constructor
@@ -42,10 +38,6 @@ abstract contract AllocatorStrategyBase is
     function initialize(bytes32 _strategyId, IDAO _dao, address _plugin, bytes calldata) public virtual initializer {
         __DaoAuthorizableUpgradeable_init(_dao);
         __ERC165_init();
-
-        // Set plugin as owner for backward compatibility, but store plugin separately
-        __Ownable_init();
-        _transferOwnership(_plugin);
 
         plugin = _plugin;
         strategyId = _strategyId;

--- a/src/allocatorStrategies/MerkleDistributorStrategy.sol
+++ b/src/allocatorStrategies/MerkleDistributorStrategy.sol
@@ -100,11 +100,14 @@ contract MerkleDistributorStrategy is AllocatorStrategyBase {
     }
 
     /// @inheritdoc IAllocatorStrategy
-    function setAllocationCampaign(uint256 _campaignId, bytes calldata _auxData) public override {
-        if (msg.sender != owner()) {
-            revert OnlyDAOAllowed(msg.sender);
-        }
-
+    function setAllocationCampaign(
+        uint256 _campaignId,
+        bytes calldata _auxData
+    )
+        public
+        override
+        auth(STRATEGY_MANAGER_PERMISSION_ID)
+    {
         // Check if campaign already exists
         if (merkleCampaigns[_campaignId].merkleRoot != bytes32(0)) {
             revert MerkleCampaignAlreadyExists(_campaignId);
@@ -163,11 +166,13 @@ contract MerkleDistributorStrategy is AllocatorStrategyBase {
     /// @notice Updates the merkle root for an existing campaign
     /// @param _campaignId The campaign ID to update
     /// @param _auxData The encoded data containing the new merkle root
-    function updateCampaignMerkleRoot(uint256 _campaignId, bytes calldata _auxData) external {
-        if (msg.sender != address(dao())) {
-            revert OnlyDAOAllowed(msg.sender);
-        }
-
+    function updateCampaignMerkleRoot(
+        uint256 _campaignId,
+        bytes calldata _auxData
+    )
+        external
+        auth(STRATEGY_MANAGER_PERMISSION_ID)
+    {
         // Check if campaign is paused (not active, or ended)
         // The reason for this is so it's safe to take snapshots
         if (!CapitalDistributorPlugin(plugin).isCampaignPaused(_campaignId)) {

--- a/src/factories/ActionEncoderFactory.sol
+++ b/src/factories/ActionEncoderFactory.sol
@@ -75,17 +75,19 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
     /// @notice Deploys a new instance of a registered action encoder type
     /// @param _encoderId The unique identifier for the action encoder
     /// @param _dao The DAO address for which the encoder is being deployed
+    /// @param _plugin The plugin address for which the encoder is being deployed
     /// @param _initializationParams Initialization parameters for the action encoder
     /// @return encoder The address of the deployed action encoder instance
     function deployActionEncoder(
         bytes32 _encoderId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _initializationParams
     )
         public
         returns (IPayoutActionEncoder encoder)
     {
-        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _initializationParams);
+        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _plugin, _initializationParams);
 
         // Check if encoder with these parameters already exists
         IPayoutActionEncoder existingEncoder = deployedInstances[deploymentId];
@@ -93,48 +95,52 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
             revert InstanceAlreadyDeployed(deploymentId, address(existingEncoder));
         }
 
-        return _deployActionEncoder(_encoderId, _dao, _initializationParams, deploymentId);
+        return _deployActionEncoder(_encoderId, _dao, _plugin, _initializationParams, deploymentId);
     }
 
     /// @notice Gets an existing action encoder or deploys a new one if it doesn't exist
     /// @param _encoderId The unique identifier for the action encoder
     /// @param _dao The DAO address for which the encoder is being deployed
+    /// @param _plugin The plugin address for which the encoder is being deployed
     /// @param _initializationParams Initialization parameters for the action encoder
     /// @return encoder The address of the action encoder instance
     function getOrDeployActionEncoder(
         bytes32 _encoderId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _initializationParams
     )
         external
         returns (IPayoutActionEncoder encoder)
     {
-        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _initializationParams);
+        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _plugin, _initializationParams);
 
         encoder = deployedInstances[deploymentId];
         if (address(encoder) != address(0)) {
             return encoder;
         }
 
-        return _deployActionEncoder(_encoderId, _dao, _initializationParams, deploymentId);
+        return _deployActionEncoder(_encoderId, _dao, _plugin, _initializationParams, deploymentId);
     }
 
     /// @notice Checks if an action encoder deployment exists for given parameters
     /// @param _encoderId The unique identifier for the action encoder
     /// @param _dao The DAO address to check for
+    /// @param _plugin The plugin address to check for
     /// @param _initializationParams Additional deployment parameters
     /// @return exists True if a deployment exists, false otherwise
     /// @return encoder The address of the deployed encoder if it exists, zero address otherwise
     function hasDeployment(
         bytes32 _encoderId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _initializationParams
     )
         external
         view
         returns (bool exists, IPayoutActionEncoder encoder)
     {
-        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _initializationParams);
+        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _plugin, _initializationParams);
         encoder = deployedInstances[deploymentId];
         exists = address(encoder) != address(0);
     }
@@ -148,6 +154,7 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
     function _deployActionEncoder(
         bytes32 _encoderId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _initializationParams,
         bytes32 _deploymentId
     )
@@ -161,7 +168,7 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
         }
 
         bytes memory initCalldata = abi.encodeWithSignature(
-            "initialize(bytes32,address,address,bytes)", _encoderId, address(_dao), msg.sender, _initializationParams
+            "initialize(bytes32,address,bytes)", _encoderId, address(_dao), _initializationParams
         );
 
         address instance = _deployAndInitialize(_encoderId, encoderType.implementation, initCalldata);
@@ -170,7 +177,7 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
         deployedInstances[_deploymentId] = encoder;
         instanceToType[address(encoder)] = _encoderId;
 
-        emit InstanceDeployed(_encoderId, address(encoder), _deploymentId, msg.sender);
+        emit InstanceDeployed(_encoderId, address(encoder), _deploymentId, _plugin);
         emit ActionEncoderDeployed(_encoderId, encoder);
 
         return encoder;

--- a/src/factories/AllocatorStrategyFactory.sol
+++ b/src/factories/AllocatorStrategyFactory.sol
@@ -135,18 +135,20 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
      * @notice Deploys a new instance of a registered strategy type.
      * @param _strategyId The strategy type to deploy.
      * @param _dao The DAO address for initialization.
+     * @param _plugin The plugin address for initialization.
      * @param _deploymentParams Additional deployment parameters.
      * @return strategy The address of the deployed strategy.
      */
     function deployStrategy(
         bytes32 _strategyId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _deploymentParams
     )
         public
         returns (address strategy)
     {
-        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _deploymentParams);
+        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _plugin, _deploymentParams);
 
         // Check if strategy with these parameters already exists
         address existingStrategy = deployedInstances[deploymentId];
@@ -154,38 +156,41 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
             revert InstanceAlreadyDeployed(deploymentId, existingStrategy);
         }
 
-        return _deployStrategy(_strategyId, _dao, _deploymentParams, deploymentId);
+        return _deployStrategy(_strategyId, _dao, _plugin, _deploymentParams, deploymentId);
     }
 
     /**
      * @notice Gets an existing strategy instance or deploys a new one if it doesn't exist.
      * @param _strategyId The strategy type to get or deploy.
      * @param _dao The DAO address for initialization.
+     * @param _plugin The plugin address for initialization.
      * @param _deploymentParams Additional deployment parameters.
      * @return strategy The address of the existing or newly deployed strategy.
      */
     function getOrDeployStrategy(
         bytes32 _strategyId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _deploymentParams
     )
         external
         returns (address strategy)
     {
-        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _deploymentParams);
+        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _plugin, _deploymentParams);
 
         strategy = deployedInstances[deploymentId];
         if (strategy != address(0)) {
             return strategy;
         }
 
-        return _deployStrategy(_strategyId, _dao, _deploymentParams, deploymentId);
+        return _deployStrategy(_strategyId, _dao, _plugin, _deploymentParams, deploymentId);
     }
 
     /**
      * @notice Checks if a strategy with given parameters already exists.
      * @param _strategyId The strategy type ID.
      * @param _dao The DAO address.
+     * @param _plugin The plugin address.
      * @param _deploymentParams Additional deployment parameters.
      * @return exists True if the strategy exists, false otherwise.
      * @return strategy The address of the existing strategy (zero if doesn't exist).
@@ -193,13 +198,14 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
     function hasDeployment(
         bytes32 _strategyId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _deploymentParams
     )
         external
         view
         returns (bool exists, address strategy)
     {
-        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _deploymentParams);
+        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _plugin, _deploymentParams);
         strategy = deployedInstances[deploymentId];
         // Avoid redundant comparison by using inline assembly for gas optimization
         assembly {
@@ -230,6 +236,7 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
      * @notice Internal function to deploy a strategy with pre-computed hash.
      * @param _strategyId The strategy type to deploy.
      * @param _dao The DAO address for initialization.
+     * @param _plugin The plugin address for initialization.
      * @param _deploymentParams Additional deployment parameters.
      * @param _deploymentId Pre-computed deployment identifier.
      * @return strategy The address of the deployed strategy.
@@ -237,6 +244,7 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
     function _deployStrategy(
         bytes32 _strategyId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _deploymentParams,
         bytes32 _deploymentId
     )
@@ -252,7 +260,7 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
 
         // Initialize the strategy
         bytes memory initCalldata = abi.encodeWithSignature(
-            "initialize(bytes32,address,address,bytes)", _strategyId, address(_dao), msg.sender, _deploymentParams
+            "initialize(bytes32,address,address,bytes)", _strategyId, address(_dao), _plugin, _deploymentParams
         );
 
         // Deploy and initialize using base class utility
@@ -262,7 +270,7 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
         deployedInstances[_deploymentId] = strategy;
         instanceToType[strategy] = _strategyId;
 
-        emit InstanceDeployed(_strategyId, strategy, _deploymentId, msg.sender);
+        emit InstanceDeployed(_strategyId, strategy, _deploymentId, _plugin);
         emit StrategyDeployed(_strategyId, strategy);
 
         return strategy;

--- a/src/factories/FactoryBase.sol
+++ b/src/factories/FactoryBase.sol
@@ -141,18 +141,20 @@ abstract contract FactoryBase is ReentrancyGuard {
     /// @notice Computes a hash for deployment parameters with additional data
     /// @param _typeId The type identifier
     /// @param _dao The DAO address
+    /// @param _plugin The plugin address
     /// @param _deploymentParams Additional data to include in the hash
     /// @return deploymentId The computed hash
     function _computeDeploymentId(
         bytes32 _typeId,
         IDAO _dao,
+        address _plugin,
         bytes memory _deploymentParams
     )
         internal
         pure
         returns (bytes32 deploymentId)
     {
-        return keccak256(abi.encode(_typeId, address(_dao), _deploymentParams));
+        return keccak256(abi.encode(_typeId, address(_dao), _plugin, _deploymentParams));
     }
 
     /// @notice Checks if a type is registered

--- a/src/interfaces/IActionEncoderFactory.sol
+++ b/src/interfaces/IActionEncoderFactory.sol
@@ -28,12 +28,14 @@ interface IActionEncoderFactory {
      * @notice Gets an existing action encoder or deploys a new one if it doesn't exist
      * @param _encoderId The unique identifier for the action encoder
      * @param _dao The DAO address for which the encoder is being deployed
+     * @param _plugin The plugin address for which the encoder is being deployed
      * @param _params Initialization parameters for the action encoder
      * @return actionEncoder The address of the action encoder instance
      */
     function getOrDeployActionEncoder(
         bytes32 _encoderId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _params
     )
         external

--- a/src/interfaces/IAllocatorStrategyFactory.sol
+++ b/src/interfaces/IAllocatorStrategyFactory.sol
@@ -31,12 +31,15 @@ interface IAllocatorStrategyFactory {
     /**
      * @notice Deploys a new instance of a registered strategy type.
      * @param _strategyId The strategy type to deploy.
+     * @param _dao The DAO address.
+     * @param _plugin The plugin address.
      * @param _params Deployment parameters for the strategy.
      * @return strategy The address of the deployed strategy.
      */
     function deployStrategy(
         bytes32 _strategyId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _params
     )
         external
@@ -45,12 +48,15 @@ interface IAllocatorStrategyFactory {
     /**
      * @notice Gets an existing strategy instance or deploys a new one if it doesn't exist.
      * @param _strategyId The strategy type to get or deploy.
+     * @param _dao The DAO address.
+     * @param _plugin The plugin address.
      * @param _params Deployment parameters for the strategy.
      * @return strategy The address of the existing or newly deployed strategy.
      */
     function getOrDeployStrategy(
         bytes32 _strategyId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _params
     )
         external

--- a/src/payoutActionEncoders/PayoutActionEncoderBase.sol
+++ b/src/payoutActionEncoders/PayoutActionEncoderBase.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.29;
 
 import { IPayoutActionEncoder } from "../interfaces/IPayoutActionEncoder.sol";
 import { DaoAuthorizableUpgradeable } from "@aragon/commons/permission/auth/DaoAuthorizableUpgradeable.sol";
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { Action } from "@aragon/commons/executors/IExecutor.sol";
@@ -13,17 +12,15 @@ import { IDAO } from "@aragon/commons/dao/IDAO.sol";
 /// @notice Base contract implementing the IPayoutActionEncoder interface.
 /// @dev Provides common functionality for action encoders. Implementing contracts should override
 /// abstract functions to define specific allocation logic.
-abstract contract PayoutActionEncoderBase is
-    IPayoutActionEncoder,
-    DaoAuthorizableUpgradeable,
-    OwnableUpgradeable,
-    ERC165Upgradeable
-{
+abstract contract PayoutActionEncoderBase is IPayoutActionEncoder, DaoAuthorizableUpgradeable, ERC165Upgradeable {
     bytes32 public encoderId;
+
+    bytes32 public constant ENCODER_MANAGER_PERMISSION_ID = keccak256("ENCODER_MANAGER_PERMISSION");
 
     // =========================================================================
     // Constructor
     // =========================================================================
+
     constructor() {
         // Disable initializers to prevent implementation contract from being initialized
         _disableInitializers();
@@ -36,12 +33,9 @@ abstract contract PayoutActionEncoderBase is
     /// @notice Initializes the action encoder with the given parameters
     /// @param _encoderId The type ID of the strategy
     /// @param _dao The DAO that will control this strategy
-    function initialize(bytes32 _encoderId, IDAO _dao, address _owner, bytes calldata) public virtual initializer {
+    function initialize(bytes32 _encoderId, IDAO _dao, bytes calldata) public virtual initializer {
         __DaoAuthorizableUpgradeable_init(_dao);
-        // Owner will be set directly to the plugin who's calling the initialize
-        __Ownable_init();
         __ERC165_init();
-        _transferOwnership(_owner);
 
         encoderId = _encoderId;
     }

--- a/src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol
+++ b/src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol
@@ -34,10 +34,14 @@ contract VaultDepositPayoutActionEncoder is PayoutActionEncoderBase {
     error OnlyOwner(address caller);
 
     // @inheritdoc PayoutActionEncoderBase
-    function setupCampaign(uint256 _campaignId, bytes calldata _auxData) external override {
-        if (msg.sender != owner()) {
-            revert OnlyOwner(msg.sender);
-        }
+    function setupCampaign(
+        uint256 _campaignId,
+        bytes calldata _auxData
+    )
+        external
+        override
+        auth(ENCODER_MANAGER_PERMISSION_ID)
+    {
         address vaultAddress = decodeSetupCampaignParams(_auxData);
         if (vaultAddress == address(0)) {
             revert ZeroAddressNotAllowed();


### PR DESCRIPTION
The changes implement a permission-based management system for strategies and encoders, replacing direct ownership with DAO-controlled access. This includes:

- Added STRATEGY_MANAGER and ENCODER_MANAGER permissions 
- Updated factory deployments to include plugin address 
- Removed Ownable from base contracts 
- Added permission checks to strategy and encoder functions