### PR TITLE
Fix permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "v1.3.0"
 
       - name: "Install Bun"
         uses: "oven-sh/setup-bun@v1"
@@ -45,6 +47,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "v1.3.0"
 
       - name: "Install Bun"
         uses: "oven-sh/setup-bun@v1"
@@ -68,6 +72,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "v1.3.0"
 
       - name: "Install Bun"
         uses: "oven-sh/setup-bun@v1"
@@ -92,6 +98,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "v1.3.0"
 
       - name: "Install Bun"
         uses: "oven-sh/setup-bun@v1"

--- a/src/CapitalDistributorPlugin.sol
+++ b/src/CapitalDistributorPlugin.sol
@@ -266,6 +266,49 @@ contract CapitalDistributorPlugin is
         actionEncoderFactory = _actionEncoderFactory;
     }
 
+    /// @notice Deploys a new strategy using the allocator strategy factory.
+    /// @param _strategyId The ID of the strategy to deploy.
+    /// @param _deploymentParams The parameters for the strategy deployment.
+    /// @return strategyAddress The address of the deployed strategy.
+    function deployStrategy(
+        bytes32 _strategyId,
+        bytes calldata _deploymentParams
+    )
+        external
+        auth(CAMPAIGN_MANAGER_PERMISSION_ID)
+        returns (address strategyAddress)
+    {
+        // Deploy and setup allocation strategy
+        {
+            strategyAddress = allocatorStrategyFactory.deployStrategy(_strategyId, dao(), _deploymentParams);
+            if (strategyAddress == address(0)) {
+                revert FactoryDeploymentFailed("AllocatorStrategy");
+            }
+        }
+    }
+
+    /// @notice Deploys a new action encoder using the action encoder factory.
+    /// @param _actionEncoderId The ID of the action encoder to deploy.
+    /// @param _deploymentParams The parameters for the action encoder deployment.
+    /// @return actionEncoderAddress The address of the deployed action encoder.
+    function deployActionEncoder(
+        bytes32 _actionEncoderId,
+        bytes calldata _deploymentParams
+    )
+        external
+        auth(CAMPAIGN_MANAGER_PERMISSION_ID)
+        returns (address actionEncoderAddress)
+    {
+        // Deploy and setup action encoder
+        {
+            actionEncoderAddress =
+                address(actionEncoderFactory.deployActionEncoder(_actionEncoderId, dao(), _deploymentParams));
+            if (actionEncoderAddress == address(0)) {
+                revert FactoryDeploymentFailed("ActionEncoder");
+            }
+        }
+    }
+
     /**
      * @notice Creates the details for a specific campaign.
      * @dev This function allows an authorized address to configure a new campaign.

--- a/src/allocatorStrategies/AllocatorStrategyBase.sol
+++ b/src/allocatorStrategies/AllocatorStrategyBase.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.29;
 import { IAllocatorStrategy } from "../interfaces/IAllocatorStrategy.sol";
 import { IAllocatorStrategyFactory } from "../interfaces/IAllocatorStrategyFactory.sol";
 import { DaoAuthorizableUpgradeable } from "@aragon/commons/permission/auth/DaoAuthorizableUpgradeable.sol";
-import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/src/allocatorStrategies/AllocatorStrategyBase.sol
+++ b/src/allocatorStrategies/AllocatorStrategyBase.sol
@@ -121,9 +121,10 @@ abstract contract AllocatorStrategyBase is
     /**
      * @dev Checks if the sender is the owner or is DAO
      */
-    function _checkOwnerOrDao() internal view {
-        if (owner() != _msgSender() && address(dao()) != _msgSender()) {
-            revert NotAuthorized(_msgSender());
+    function _checkOwnerOrDao() internal view virtual {
+        address sender = _msgSender();
+        if (owner() != sender && address(dao()) != sender) {
+            revert NotAuthorized(sender);
         }
     }
 

--- a/src/allocatorStrategies/AllocatorStrategyBase.sol
+++ b/src/allocatorStrategies/AllocatorStrategyBase.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.29;
 import { IAllocatorStrategy } from "../interfaces/IAllocatorStrategy.sol";
 import { IAllocatorStrategyFactory } from "../interfaces/IAllocatorStrategyFactory.sol";
 import { DaoAuthorizableUpgradeable } from "@aragon/commons/permission/auth/DaoAuthorizableUpgradeable.sol";
+import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -19,6 +20,9 @@ abstract contract AllocatorStrategyBase is
     OwnableUpgradeable,
     ERC165Upgradeable
 {
+    /// @notice The ID of the permission required to manage strategy operations
+    bytes32 public constant STRATEGY_MANAGER_PERMISSION_ID = keccak256("STRATEGY_MANAGER_PERMISSION");
+
     bytes32 public strategyId;
     address public plugin;
     address public factory;
@@ -97,5 +101,44 @@ abstract contract AllocatorStrategyBase is
         returns (bool)
     {
         return interfaceId == type(IAllocatorStrategy).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner.
+     * Make sure to give permissions to the DAO to manage the strategy.
+     */
+    function renounceOwnership() public override authOrOwner(STRATEGY_MANAGER_PERMISSION_ID) {
+        super.renounceOwnership();
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     */
+    function transferOwnership(address newOwner) public override authOrOwner(STRATEGY_MANAGER_PERMISSION_ID) {
+        super.transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Checks if the sender is the owner or has the required permission.
+     */
+    function _checkAuthOrOwner(bytes32 _permissionId) internal view {
+        if (owner() != _msgSender() && !dao().hasPermission(address(this), _msgSender(), _permissionId, _msgData())) {
+            revert DaoUnauthorized({
+                dao: address(dao()),
+                where: address(this),
+                who: _msgSender(),
+                permissionId: _permissionId
+            });
+        }
+    }
+
+    /// @notice Modifier that checks both ownership and DAO permission
+    /// @dev Custom modifier for strategy management functions
+    modifier authOrOwner(bytes32 _permissionId) {
+        _checkAuthOrOwner(_permissionId);
+        _;
     }
 }

--- a/src/allocatorStrategies/AllocatorStrategyBase.sol
+++ b/src/allocatorStrategies/AllocatorStrategyBase.sol
@@ -20,9 +20,6 @@ abstract contract AllocatorStrategyBase is
     OwnableUpgradeable,
     ERC165Upgradeable
 {
-    /// @notice The ID of the permission required to manage strategy operations
-    bytes32 public constant STRATEGY_MANAGER_PERMISSION_ID = keccak256("STRATEGY_MANAGER_PERMISSION");
-
     bytes32 public strategyId;
     address public plugin;
     address public factory;
@@ -110,36 +107,31 @@ abstract contract AllocatorStrategyBase is
      * NOTE: Renouncing ownership will leave the contract without an owner.
      * Make sure to give permissions to the DAO to manage the strategy.
      */
-    function renounceOwnership() public override authOrOwner(STRATEGY_MANAGER_PERMISSION_ID) {
+    function renounceOwnership() public override ownerOrDao {
         _transferOwnership(address(0));
     }
 
     /**
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      */
-    function transferOwnership(address newOwner) public override authOrOwner(STRATEGY_MANAGER_PERMISSION_ID) {
+    function transferOwnership(address newOwner) public override ownerOrDao {
         require(newOwner != address(0), "Ownable: new owner is the zero address");
         _transferOwnership(newOwner);
     }
 
     /**
-     * @dev Checks if the sender is the owner or has the required permission.
+     * @dev Checks if the sender is the owner or is DAO
      */
-    function _checkAuthOrOwner(bytes32 _permissionId) internal view {
-        if (owner() != _msgSender() && !dao().hasPermission(address(this), _msgSender(), _permissionId, _msgData())) {
-            revert DaoUnauthorized({
-                dao: address(dao()),
-                where: address(this),
-                who: _msgSender(),
-                permissionId: _permissionId
-            });
+    function _checkOwnerOrDao() internal view {
+        if (owner() != _msgSender() && address(dao()) != _msgSender()) {
+            revert NotAuthorized(_msgSender());
         }
     }
 
-    /// @notice Modifier that checks both ownership and DAO permission
+    /// @notice Modifier that checks both ownership or is DAO
     /// @dev Custom modifier for strategy management functions
-    modifier authOrOwner(bytes32 _permissionId) {
-        _checkAuthOrOwner(_permissionId);
+    modifier ownerOrDao() {
+        _checkOwnerOrDao();
         _;
     }
 }

--- a/src/allocatorStrategies/AllocatorStrategyBase.sol
+++ b/src/allocatorStrategies/AllocatorStrategyBase.sol
@@ -111,14 +111,15 @@ abstract contract AllocatorStrategyBase is
      * Make sure to give permissions to the DAO to manage the strategy.
      */
     function renounceOwnership() public override authOrOwner(STRATEGY_MANAGER_PERMISSION_ID) {
-        super.renounceOwnership();
+        _transferOwnership(address(0));
     }
 
     /**
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      */
     function transferOwnership(address newOwner) public override authOrOwner(STRATEGY_MANAGER_PERMISSION_ID) {
-        super.transferOwnership(newOwner);
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _transferOwnership(newOwner);
     }
 
     /**

--- a/src/allocatorStrategies/MerkleDistributorStrategy.sol
+++ b/src/allocatorStrategies/MerkleDistributorStrategy.sol
@@ -100,14 +100,7 @@ contract MerkleDistributorStrategy is AllocatorStrategyBase {
     }
 
     /// @inheritdoc IAllocatorStrategy
-    function setAllocationCampaign(
-        uint256 _campaignId,
-        bytes calldata _auxData
-    )
-        public
-        override
-        authOrOwner(STRATEGY_MANAGER_PERMISSION_ID)
-    {
+    function setAllocationCampaign(uint256 _campaignId, bytes calldata _auxData) public override ownerOrDao {
         // Check if campaign already exists
         if (merkleCampaigns[_campaignId].merkleRoot != bytes32(0)) {
             revert MerkleCampaignAlreadyExists(_campaignId);
@@ -166,13 +159,7 @@ contract MerkleDistributorStrategy is AllocatorStrategyBase {
     /// @notice Updates the merkle root for an existing campaign
     /// @param _campaignId The campaign ID to update
     /// @param _auxData The encoded data containing the new merkle root
-    function updateCampaignMerkleRoot(
-        uint256 _campaignId,
-        bytes calldata _auxData
-    )
-        external
-        authOrOwner(STRATEGY_MANAGER_PERMISSION_ID)
-    {
+    function updateCampaignMerkleRoot(uint256 _campaignId, bytes calldata _auxData) external ownerOrDao {
         // Check if campaign is paused (not active, or ended)
         // The reason for this is so it's safe to take snapshots
         if (!CapitalDistributorPlugin(plugin).isCampaignPaused(_campaignId)) {

--- a/src/allocatorStrategies/MerkleDistributorStrategy.sol
+++ b/src/allocatorStrategies/MerkleDistributorStrategy.sol
@@ -100,11 +100,14 @@ contract MerkleDistributorStrategy is AllocatorStrategyBase {
     }
 
     /// @inheritdoc IAllocatorStrategy
-    function setAllocationCampaign(uint256 _campaignId, bytes calldata _auxData) public override {
-        if (msg.sender != owner()) {
-            revert OnlyDAOAllowed(msg.sender);
-        }
-
+    function setAllocationCampaign(
+        uint256 _campaignId,
+        bytes calldata _auxData
+    )
+        public
+        override
+        authOrOwner(STRATEGY_MANAGER_PERMISSION_ID)
+    {
         // Check if campaign already exists
         if (merkleCampaigns[_campaignId].merkleRoot != bytes32(0)) {
             revert MerkleCampaignAlreadyExists(_campaignId);
@@ -163,11 +166,13 @@ contract MerkleDistributorStrategy is AllocatorStrategyBase {
     /// @notice Updates the merkle root for an existing campaign
     /// @param _campaignId The campaign ID to update
     /// @param _auxData The encoded data containing the new merkle root
-    function updateCampaignMerkleRoot(uint256 _campaignId, bytes calldata _auxData) external {
-        if (msg.sender != address(dao())) {
-            revert OnlyDAOAllowed(msg.sender);
-        }
-
+    function updateCampaignMerkleRoot(
+        uint256 _campaignId,
+        bytes calldata _auxData
+    )
+        external
+        authOrOwner(STRATEGY_MANAGER_PERMISSION_ID)
+    {
         // Check if campaign is paused (not active, or ended)
         // The reason for this is so it's safe to take snapshots
         if (!CapitalDistributorPlugin(plugin).isCampaignPaused(_campaignId)) {

--- a/src/factories/ActionEncoderFactory.sol
+++ b/src/factories/ActionEncoderFactory.sol
@@ -85,7 +85,7 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
         public
         returns (IPayoutActionEncoder encoder)
     {
-        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _initializationParams);
+        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, msg.sender, _initializationParams);
 
         // Check if encoder with these parameters already exists
         IPayoutActionEncoder existingEncoder = deployedInstances[deploymentId];
@@ -109,7 +109,7 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
         external
         returns (IPayoutActionEncoder encoder)
     {
-        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _initializationParams);
+        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, msg.sender, _initializationParams);
 
         encoder = deployedInstances[deploymentId];
         if (address(encoder) != address(0)) {
@@ -128,13 +128,14 @@ contract ActionEncoderFactory is FactoryBase, IActionEncoderFactory {
     function hasDeployment(
         bytes32 _encoderId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _initializationParams
     )
         external
         view
         returns (bool exists, IPayoutActionEncoder encoder)
     {
-        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _initializationParams);
+        bytes32 deploymentId = _computeDeploymentId(_encoderId, _dao, _plugin, _initializationParams);
         encoder = deployedInstances[deploymentId];
         exists = address(encoder) != address(0);
     }

--- a/src/factories/AllocatorStrategyFactory.sol
+++ b/src/factories/AllocatorStrategyFactory.sol
@@ -146,7 +146,7 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
         public
         returns (address strategy)
     {
-        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _deploymentParams);
+        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, msg.sender, _deploymentParams);
 
         // Check if strategy with these parameters already exists
         address existingStrategy = deployedInstances[deploymentId];
@@ -172,7 +172,7 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
         external
         returns (address strategy)
     {
-        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _deploymentParams);
+        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, msg.sender, _deploymentParams);
 
         strategy = deployedInstances[deploymentId];
         if (strategy != address(0)) {
@@ -193,13 +193,14 @@ contract AllocatorStrategyFactory is FactoryBase, IAllocatorStrategyFactory {
     function hasDeployment(
         bytes32 _strategyId,
         IDAO _dao,
+        address _plugin,
         bytes calldata _deploymentParams
     )
         external
         view
         returns (bool exists, address strategy)
     {
-        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _deploymentParams);
+        bytes32 deploymentId = _computeDeploymentId(_strategyId, _dao, _plugin, _deploymentParams);
         strategy = deployedInstances[deploymentId];
         // Avoid redundant comparison by using inline assembly for gas optimization
         assembly {

--- a/src/factories/FactoryBase.sol
+++ b/src/factories/FactoryBase.sol
@@ -146,13 +146,14 @@ abstract contract FactoryBase is ReentrancyGuard {
     function _computeDeploymentId(
         bytes32 _typeId,
         IDAO _dao,
+        address _plugin,
         bytes memory _deploymentParams
     )
         internal
         pure
         returns (bytes32 deploymentId)
     {
-        return keccak256(abi.encode(_typeId, address(_dao), _deploymentParams));
+        return keccak256(abi.encode(_typeId, address(_dao), _plugin, _deploymentParams));
     }
 
     /// @notice Checks if a type is registered

--- a/src/interfaces/IAllocatorStrategy.sol
+++ b/src/interfaces/IAllocatorStrategy.sol
@@ -19,11 +19,6 @@ interface IAllocatorStrategy is IERC165 {
     event AllocationCampaignCreated(address indexed _dao, uint256 indexed _campaignId);
 
     // =========================================================================
-    // Errors
-    // =========================================================================
-    error OnlyDAOAllowed(address account);
-
-    // =========================================================================
     // View Functions
     // =========================================================================
 

--- a/src/interfaces/IAllocatorStrategy.sol
+++ b/src/interfaces/IAllocatorStrategy.sol
@@ -10,6 +10,11 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 /// Implementing contracts will define the specific logic for allocation and eligibility.
 interface IAllocatorStrategy is IERC165 {
     // =========================================================================
+    // Errors
+    // =========================================================================
+    error NotAuthorized(address _sender);
+
+    // =========================================================================
     // Events
     // =========================================================================
 

--- a/src/interfaces/IPayoutActionEncoder.sol
+++ b/src/interfaces/IPayoutActionEncoder.sol
@@ -7,8 +7,6 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 /// @title IPayoutActionEncoder
 /// @notice Interface for contracts that construct the DAO actions required to execute a payout.
 interface IPayoutActionEncoder {
-    error OnlyDAOAllowed(address account);
-
     /// @notice Retrieves the encoder ID associated with a campaign.
     /// @return The encoder ID.
     function encoderId() external view returns (bytes32);

--- a/src/interfaces/IPayoutActionEncoder.sol
+++ b/src/interfaces/IPayoutActionEncoder.sol
@@ -7,6 +7,11 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 /// @title IPayoutActionEncoder
 /// @notice Interface for contracts that construct the DAO actions required to execute a payout.
 interface IPayoutActionEncoder {
+    // =========================================================================
+    // Errors
+    // =========================================================================
+    error NotAuthorized(address _sender);
+
     /// @notice Retrieves the encoder ID associated with a campaign.
     /// @return The encoder ID.
     function encoderId() external view returns (bytes32);

--- a/src/payoutActionEncoders/PayoutActionEncoderBase.sol
+++ b/src/payoutActionEncoders/PayoutActionEncoderBase.sol
@@ -20,9 +20,6 @@ abstract contract PayoutActionEncoderBase is
     OwnableUpgradeable,
     ERC165Upgradeable
 {
-    /// @notice The ID of the permission required to manage encoder operations
-    bytes32 public constant ENCODER_MANAGER_PERMISSION_ID = keccak256("ENCODER_MANAGER_PERMISSION");
-
     bytes32 public encoderId;
 
     // =========================================================================
@@ -91,36 +88,31 @@ abstract contract PayoutActionEncoderBase is
      * NOTE: Renouncing ownership will leave the contract without an owner.
      * Make sure to give permissions to the DAO to manage the encoder.
      */
-    function renounceOwnership() public override authOrOwner(ENCODER_MANAGER_PERMISSION_ID) {
+    function renounceOwnership() public override ownerOrDao {
         _transferOwnership(address(0));
     }
 
     /**
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      */
-    function transferOwnership(address newOwner) public override authOrOwner(ENCODER_MANAGER_PERMISSION_ID) {
+    function transferOwnership(address newOwner) public override ownerOrDao {
         require(newOwner != address(0), "Ownable: new owner is the zero address");
         _transferOwnership(newOwner);
     }
 
     /**
-     * @dev Checks if the sender is the owner or has the required permission.
+     * @dev Checks if the sender is the owner or is DAO
      */
-    function _checkAuthOrOwner(bytes32 _permissionId) internal view {
-        if (owner() != _msgSender() && !dao().hasPermission(address(this), _msgSender(), _permissionId, _msgData())) {
-            revert DaoUnauthorized({
-                dao: address(dao()),
-                where: address(this),
-                who: _msgSender(),
-                permissionId: _permissionId
-            });
+    function _checkOwnerOrDao() internal view {
+        if (owner() != _msgSender() && address(dao()) != _msgSender()) {
+            revert NotAuthorized(_msgSender());
         }
     }
 
-    /// @notice Modifier that checks both ownership and DAO permission
+    /// @notice Modifier that checks both ownership or is DAO
     /// @dev Custom modifier for strategy management functions
-    modifier authOrOwner(bytes32 _permissionId) {
-        _checkAuthOrOwner(_permissionId);
+    modifier ownerOrDao() {
+        _checkOwnerOrDao();
         _;
     }
 }

--- a/src/payoutActionEncoders/PayoutActionEncoderBase.sol
+++ b/src/payoutActionEncoders/PayoutActionEncoderBase.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.29;
 
 import { IPayoutActionEncoder } from "../interfaces/IPayoutActionEncoder.sol";
 import { DaoAuthorizableUpgradeable } from "@aragon/commons/permission/auth/DaoAuthorizableUpgradeable.sol";
-import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/src/payoutActionEncoders/PayoutActionEncoderBase.sol
+++ b/src/payoutActionEncoders/PayoutActionEncoderBase.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.29;
 
 import { IPayoutActionEncoder } from "../interfaces/IPayoutActionEncoder.sol";
 import { DaoAuthorizableUpgradeable } from "@aragon/commons/permission/auth/DaoAuthorizableUpgradeable.sol";
+import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
@@ -19,6 +20,9 @@ abstract contract PayoutActionEncoderBase is
     OwnableUpgradeable,
     ERC165Upgradeable
 {
+    /// @notice The ID of the permission required to manage encoder operations
+    bytes32 public constant ENCODER_MANAGER_PERMISSION_ID = keccak256("ENCODER_MANAGER_PERMISSION");
+
     bytes32 public encoderId;
 
     // =========================================================================
@@ -78,5 +82,44 @@ abstract contract PayoutActionEncoderBase is
     /// @return True if the contract supports the interface
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == type(IPayoutActionEncoder).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner.
+     * Make sure to give permissions to the DAO to manage the encoder.
+     */
+    function renounceOwnership() public override authOrOwner(ENCODER_MANAGER_PERMISSION_ID) {
+        super.renounceOwnership();
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     */
+    function transferOwnership(address newOwner) public override authOrOwner(ENCODER_MANAGER_PERMISSION_ID) {
+        super.transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Checks if the sender is the owner or has the required permission.
+     */
+    function _checkAuthOrOwner(bytes32 _permissionId) internal view {
+        if (owner() != _msgSender() && !dao().hasPermission(address(this), _msgSender(), _permissionId, _msgData())) {
+            revert DaoUnauthorized({
+                dao: address(dao()),
+                where: address(this),
+                who: _msgSender(),
+                permissionId: _permissionId
+            });
+        }
+    }
+
+    /// @notice Modifier that checks both ownership and DAO permission
+    /// @dev Custom modifier for strategy management functions
+    modifier authOrOwner(bytes32 _permissionId) {
+        _checkAuthOrOwner(_permissionId);
+        _;
     }
 }

--- a/src/payoutActionEncoders/PayoutActionEncoderBase.sol
+++ b/src/payoutActionEncoders/PayoutActionEncoderBase.sol
@@ -92,14 +92,15 @@ abstract contract PayoutActionEncoderBase is
      * Make sure to give permissions to the DAO to manage the encoder.
      */
     function renounceOwnership() public override authOrOwner(ENCODER_MANAGER_PERMISSION_ID) {
-        super.renounceOwnership();
+        _transferOwnership(address(0));
     }
 
     /**
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      */
     function transferOwnership(address newOwner) public override authOrOwner(ENCODER_MANAGER_PERMISSION_ID) {
-        super.transferOwnership(newOwner);
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _transferOwnership(newOwner);
     }
 
     /**

--- a/src/payoutActionEncoders/PayoutActionEncoderBase.sol
+++ b/src/payoutActionEncoders/PayoutActionEncoderBase.sol
@@ -102,9 +102,10 @@ abstract contract PayoutActionEncoderBase is
     /**
      * @dev Checks if the sender is the owner or is DAO
      */
-    function _checkOwnerOrDao() internal view {
-        if (owner() != _msgSender() && address(dao()) != _msgSender()) {
-            revert NotAuthorized(_msgSender());
+    function _checkOwnerOrDao() internal view virtual {
+        address sender = _msgSender();
+        if (owner() != sender && address(dao()) != sender) {
+            revert NotAuthorized(sender);
         }
     }
 

--- a/src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol
+++ b/src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol
@@ -34,10 +34,14 @@ contract VaultDepositPayoutActionEncoder is PayoutActionEncoderBase {
     error OnlyOwner(address caller);
 
     // @inheritdoc PayoutActionEncoderBase
-    function setupCampaign(uint256 _campaignId, bytes calldata _auxData) external override {
-        if (msg.sender != owner()) {
-            revert OnlyOwner(msg.sender);
-        }
+    function setupCampaign(
+        uint256 _campaignId,
+        bytes calldata _auxData
+    )
+        external
+        override
+        authOrOwner(ENCODER_MANAGER_PERMISSION_ID)
+    {
         address vaultAddress = decodeSetupCampaignParams(_auxData);
         if (vaultAddress == address(0)) {
             revert ZeroAddressNotAllowed();

--- a/src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol
+++ b/src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol
@@ -34,14 +34,7 @@ contract VaultDepositPayoutActionEncoder is PayoutActionEncoderBase {
     error OnlyOwner(address caller);
 
     // @inheritdoc PayoutActionEncoderBase
-    function setupCampaign(
-        uint256 _campaignId,
-        bytes calldata _auxData
-    )
-        external
-        override
-        authOrOwner(ENCODER_MANAGER_PERMISSION_ID)
-    {
+    function setupCampaign(uint256 _campaignId, bytes calldata _auxData) external override ownerOrDao {
         address vaultAddress = decodeSetupCampaignParams(_auxData);
         if (vaultAddress == address(0)) {
             revert ZeroAddressNotAllowed();

--- a/tests/AuthOrOwnerTest.t.sol
+++ b/tests/AuthOrOwnerTest.t.sol
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+import { Test, console2 } from "forge-std/Test.sol";
+import { AragonTest } from "./helpers/AragonTest.sol";
+import { MintableERC20 } from "./mocks/MintableERC20.sol";
+import { CapitalDistributorPlugin } from "../src/CapitalDistributorPlugin.sol";
+import { CapitalDistributorPluginSetup } from "../src/CapitalDistributorPluginSetup.sol";
+import { AllocatorStrategyFactory } from "../src/factories/AllocatorStrategyFactory.sol";
+import { ActionEncoderFactory } from "../src/factories/ActionEncoderFactory.sol";
+import { MerkleDistributorStrategy } from "../src/allocatorStrategies/MerkleDistributorStrategy.sol";
+import { VaultDepositPayoutActionEncoder } from "../src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol";
+import { AllocatorStrategyBase } from "../src/allocatorStrategies/AllocatorStrategyBase.sol";
+import { PayoutActionEncoderBase } from "../src/payoutActionEncoders/PayoutActionEncoderBase.sol";
+import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
+import { DAO } from "@aragon/osx/core/dao/DAO.sol";
+import { IPluginRepo } from "@aragon/osx/framework/plugin/repo/IPluginRepo.sol";
+
+contract AuthOrOwnerTest is AragonTest {
+    MintableERC20 token;
+    CapitalDistributorPlugin capitalDistributorPlugin;
+    
+    address testAlice = makeAddr("testAlice");
+    address testBob = makeAddr("testBob");
+    address charlie = makeAddr("charlie");
+
+    bytes32 constant STRATEGY_MANAGER_PERMISSION_ID = keccak256("STRATEGY_MANAGER_PERMISSION");
+    bytes32 constant ENCODER_MANAGER_PERMISSION_ID = keccak256("ENCODER_MANAGER_PERMISSION");
+    bytes32 constant CAMPAIGN_MANAGER_PERMISSION_ID = keccak256("CAMPAIGN_MANAGER_PERMISSION");
+
+    function setUp() public {
+        // Deploy token
+        token = new MintableERC20();
+
+        // Use the plugin already deployed by AragonTest
+        capitalDistributorPlugin = CapitalDistributorPlugin(pluginAddress[0]);
+
+        // Register the strategies we need for testing
+        vm.startPrank(address(createdDao));
+        
+        // Register merkle strategy
+        allocatorStrategyFactory.registerStrategyType(
+            toBytes32("merkle-strategy"),
+            address(new MerkleDistributorStrategy()),
+            "Merkle Distributor Strategy",
+            address(0), // No fee recipient
+            0 // No fee
+        );
+
+        // Register vault encoder  
+        actionEncoderFactory.registerActionEncoder(
+            toBytes32("vault-encoder"),
+            address(new VaultDepositPayoutActionEncoder()),
+            "Vault Deposit Payout Encoder"
+        );
+        
+        vm.stopPrank();
+    }
+
+    // =========================================================================
+    // MerkleDistributorStrategy authOrOwner Tests
+    // =========================================================================
+
+    function test_MerkleStrategy_SetAllocationCampaign_AsOwner() public {
+        // Deploy strategy
+        vm.prank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Owner should be able to call setAllocationCampaign
+        bytes32 merkleRoot = keccak256("test-merkle-root");
+        
+        vm.prank(strategy.owner());
+        strategy.setAllocationCampaign(1, abi.encode(merkleRoot));
+        
+        assertEq(strategy.getCampaignMerkleRoot(1), merkleRoot);
+    }
+
+    function test_MerkleStrategy_SetAllocationCampaign_WithPermission() public {
+        // Deploy strategy
+        vm.prank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Grant permission to testAlice
+        vm.prank(address(createdDao));
+        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
+        
+        // Alice should be able to call setAllocationCampaign
+        bytes32 merkleRoot = keccak256("test-merkle-root");
+        
+        vm.prank(testAlice);
+        strategy.setAllocationCampaign(2, abi.encode(merkleRoot));
+        
+        assertEq(strategy.getCampaignMerkleRoot(2), merkleRoot);
+    }
+
+    function test_MerkleStrategy_SetAllocationCampaign_RevertUnauthorized() public {
+        // Deploy strategy
+        vm.prank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Bob without permission should not be able to call
+        bytes32 merkleRoot = keccak256("test-merkle-root");
+        
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector, 
+                createdDao, 
+                address(strategy), 
+                testBob, 
+                STRATEGY_MANAGER_PERMISSION_ID
+            )
+        );
+        vm.prank(testBob);
+        strategy.setAllocationCampaign(3, abi.encode(merkleRoot));
+    }
+
+    function test_MerkleStrategy_UpdateMerkleRoot_AsOwner() public {
+        // Setup campaign first
+        vm.startPrank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        token.mint(address(createdDao), 10 ether);
+        
+        uint256 campaignId = capitalDistributorPlugin.createCampaign(
+            "ipfs://metadata",
+            CapitalDistributorPlugin.StrategyConfig(
+                toBytes32("merkle-strategy"), 
+                "", 
+                abi.encode(keccak256("initial-root"))
+            ),
+            CapitalDistributorPlugin.PayoutConfig(token, bytes32(0), ""),
+            CapitalDistributorPlugin.CampaignSettings(0, 0)
+        );
+        
+        // Pause campaign
+        capitalDistributorPlugin.pauseCampaign(campaignId);
+        vm.stopPrank();
+        
+        // Owner updates merkle root
+        bytes32 newRoot = keccak256("new-merkle-root");
+        vm.prank(strategy.owner());
+        strategy.updateCampaignMerkleRoot(campaignId, abi.encode(newRoot));
+        
+        assertEq(strategy.getCampaignMerkleRoot(campaignId), newRoot);
+    }
+
+    function test_MerkleStrategy_UpdateMerkleRoot_WithPermission() public {
+        // Setup campaign
+        vm.startPrank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        token.mint(address(createdDao), 10 ether);
+        
+        uint256 campaignId = capitalDistributorPlugin.createCampaign(
+            "ipfs://metadata",
+            CapitalDistributorPlugin.StrategyConfig(
+                toBytes32("merkle-strategy"), 
+                "", 
+                abi.encode(keccak256("initial-root"))
+            ),
+            CapitalDistributorPlugin.PayoutConfig(token, bytes32(0), ""),
+            CapitalDistributorPlugin.CampaignSettings(0, 0)
+        );
+        
+        capitalDistributorPlugin.pauseCampaign(campaignId);
+        
+        // Grant permission to charlie
+        createdDao.grant(address(strategy), charlie, STRATEGY_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        // Charlie updates merkle root
+        bytes32 newRoot = keccak256("charlie-new-root");
+        vm.prank(charlie);
+        strategy.updateCampaignMerkleRoot(campaignId, abi.encode(newRoot));
+        
+        assertEq(strategy.getCampaignMerkleRoot(campaignId), newRoot);
+    }
+
+    function test_MerkleStrategy_RenounceOwnership_AsOwner() public {
+        vm.prank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        address initialOwner = strategy.owner();
+        
+        vm.prank(initialOwner);
+        strategy.renounceOwnership();
+        
+        assertEq(strategy.owner(), address(0));
+    }
+
+    function test_MerkleStrategy_RenounceOwnership_WithPermission() public {
+        vm.startPrank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Grant permission to testAlice
+        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        // Now with the fix, testAlice can renounce ownership with permission
+        vm.prank(testAlice);
+        strategy.renounceOwnership();
+        
+        assertEq(strategy.owner(), address(0));
+    }
+
+    function test_MerkleStrategy_TransferOwnership_AsOwner() public {
+        vm.prank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        address initialOwner = strategy.owner();
+        
+        vm.prank(initialOwner);
+        strategy.transferOwnership(testBob);
+        
+        assertEq(strategy.owner(), testBob);
+    }
+
+    function test_MerkleStrategy_TransferOwnership_WithPermission() public {
+        vm.startPrank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Grant permission to testAlice
+        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        // Now with the fix, testAlice can transfer ownership with permission
+        vm.prank(testAlice);
+        strategy.transferOwnership(charlie);
+        
+        assertEq(strategy.owner(), charlie);
+    }
+
+    // =========================================================================
+    // VaultDepositPayoutActionEncoder authOrOwner Tests  
+    // =========================================================================
+
+    function test_VaultEncoder_SetupCampaign_AsOwner() public {
+        vm.prank(address(createdDao));
+        VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
+            address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
+        );
+        
+        address vault = makeAddr("vault");
+        
+        vm.prank(encoder.owner());
+        encoder.setupCampaign(1, abi.encode(vault));
+        
+        assertEq(encoder.campaignVaults(1), vault);
+    }
+
+    function test_VaultEncoder_SetupCampaign_WithPermission() public {
+        vm.startPrank(address(createdDao));
+        VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
+            address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
+        );
+        
+        // Grant permission to testAlice
+        createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        address vault = makeAddr("vault");
+        
+        vm.prank(testAlice);
+        encoder.setupCampaign(2, abi.encode(vault));
+        
+        assertEq(encoder.campaignVaults(2), vault);
+    }
+
+    function test_VaultEncoder_SetupCampaign_RevertUnauthorized() public {
+        vm.prank(address(createdDao));
+        VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
+            address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
+        );
+        
+        address vault = makeAddr("vault");
+        
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                createdDao,
+                address(encoder),
+                testBob,
+                ENCODER_MANAGER_PERMISSION_ID
+            )
+        );
+        vm.prank(testBob);
+        encoder.setupCampaign(3, abi.encode(vault));
+    }
+
+    function test_VaultEncoder_RenounceOwnership_AsOwner() public {
+        vm.prank(address(createdDao));
+        VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
+            address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
+        );
+        
+        address initialOwner = encoder.owner();
+        
+        vm.prank(initialOwner);
+        encoder.renounceOwnership();
+        
+        assertEq(encoder.owner(), address(0));
+    }
+
+    function test_VaultEncoder_RenounceOwnership_WithPermission() public {
+        vm.startPrank(address(createdDao));
+        VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
+            address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
+        );
+        
+        // Grant permission to testAlice
+        createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        // Now with the fix, testAlice can renounce ownership with permission
+        vm.prank(testAlice);
+        encoder.renounceOwnership();
+        
+        assertEq(encoder.owner(), address(0));
+    }
+
+    function test_VaultEncoder_TransferOwnership_AsOwner() public {
+        vm.prank(address(createdDao));
+        VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
+            address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
+        );
+        
+        address initialOwner = encoder.owner();
+        
+        vm.prank(initialOwner);
+        encoder.transferOwnership(testBob);
+        
+        assertEq(encoder.owner(), testBob);
+    }
+
+    function test_VaultEncoder_TransferOwnership_WithPermission() public {
+        vm.startPrank(address(createdDao));
+        VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
+            address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
+        );
+        
+        // Grant permission to testAlice
+        createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        // Now with the fix, testAlice can transfer ownership with permission
+        vm.prank(testAlice);
+        encoder.transferOwnership(charlie);
+        
+        assertEq(encoder.owner(), charlie);
+    }
+
+    // =========================================================================
+    // Edge Cases and Complex Scenarios
+    // =========================================================================
+
+    function test_OwnershipTransferAndPermission() public {
+        // Test that new owner can operate after ownership transfer
+        vm.prank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Transfer ownership to testAlice
+        vm.prank(strategy.owner());
+        strategy.transferOwnership(testAlice);
+        
+        // Alice as new owner can set allocation
+        bytes32 merkleRoot = keccak256("testAlice-merkle-root");
+        vm.prank(testAlice);
+        strategy.setAllocationCampaign(10, abi.encode(merkleRoot));
+        
+        assertEq(strategy.getCampaignMerkleRoot(10), merkleRoot);
+    }
+
+    function test_PermissionAfterOwnershipRenounced() public {
+        // Test that permission still works after ownership is renounced
+        vm.startPrank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Grant permission to testBob before renouncing
+        createdDao.grant(address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        // Renounce ownership
+        vm.prank(strategy.owner());
+        strategy.renounceOwnership();
+        
+        // Bob can still operate with permission even though there's no owner
+        bytes32 merkleRoot = keccak256("testBob-merkle-root");
+        vm.prank(testBob);
+        strategy.setAllocationCampaign(20, abi.encode(merkleRoot));
+        
+        assertEq(strategy.getCampaignMerkleRoot(20), merkleRoot);
+        assertEq(strategy.owner(), address(0));
+    }
+
+    function test_RevokePermissionAfterGrant() public {
+        // Test revoking permissions
+        vm.startPrank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Grant permission to testAlice
+        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
+        
+        // Alice can operate
+        bytes32 merkleRoot1 = keccak256("testAlice-can-operate");
+        vm.startPrank(testAlice);
+        strategy.setAllocationCampaign(30, abi.encode(merkleRoot1));
+        vm.stopPrank();
+        
+        // Revoke permission
+        vm.prank(address(createdDao));
+        createdDao.revoke(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
+        
+        // Alice cannot operate anymore
+        bytes32 merkleRoot2 = keccak256("testAlice-cannot-operate");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector,
+                createdDao,
+                address(strategy),
+                testAlice,
+                STRATEGY_MANAGER_PERMISSION_ID
+            )
+        );
+        vm.prank(testAlice);
+        strategy.setAllocationCampaign(31, abi.encode(merkleRoot2));
+    }
+
+    function test_MultipleUsersWithPermission() public {
+        // Test multiple users with same permission
+        vm.startPrank(address(createdDao));
+        address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+        MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
+        
+        // Grant permission to both testAlice and testBob
+        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
+        createdDao.grant(address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID);
+        vm.stopPrank();
+        
+        // Both can operate
+        vm.prank(testAlice);
+        strategy.setAllocationCampaign(40, abi.encode(keccak256("testAlice-root")));
+        
+        vm.prank(testBob);
+        strategy.setAllocationCampaign(41, abi.encode(keccak256("testBob-root")));
+        
+        assertEq(strategy.getCampaignMerkleRoot(40), keccak256("testAlice-root"));
+        assertEq(strategy.getCampaignMerkleRoot(41), keccak256("testBob-root"));
+    }
+
+}

--- a/tests/AuthOrOwnerTest.t.sol
+++ b/tests/AuthOrOwnerTest.t.sol
@@ -19,7 +19,7 @@ import { IPluginRepo } from "@aragon/osx/framework/plugin/repo/IPluginRepo.sol";
 contract AuthOrOwnerTest is AragonTest {
     MintableERC20 token;
     CapitalDistributorPlugin capitalDistributorPlugin;
-    
+
     address testAlice = makeAddr("testAlice");
     address testBob = makeAddr("testBob");
     address charlie = makeAddr("charlie");
@@ -37,7 +37,7 @@ contract AuthOrOwnerTest is AragonTest {
 
         // Register the strategies we need for testing
         vm.startPrank(address(createdDao));
-        
+
         // Register merkle strategy
         allocatorStrategyFactory.registerStrategyType(
             toBytes32("merkle-strategy"),
@@ -47,13 +47,11 @@ contract AuthOrOwnerTest is AragonTest {
             0 // No fee
         );
 
-        // Register vault encoder  
+        // Register vault encoder
         actionEncoderFactory.registerActionEncoder(
-            toBytes32("vault-encoder"),
-            address(new VaultDepositPayoutActionEncoder()),
-            "Vault Deposit Payout Encoder"
+            toBytes32("vault-encoder"), address(new VaultDepositPayoutActionEncoder()), "Vault Deposit Payout Encoder"
         );
-        
+
         vm.stopPrank();
     }
 
@@ -66,13 +64,13 @@ contract AuthOrOwnerTest is AragonTest {
         vm.prank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Owner should be able to call setAllocationCampaign
         bytes32 merkleRoot = keccak256("test-merkle-root");
-        
+
         vm.prank(strategy.owner());
         strategy.setAllocationCampaign(1, abi.encode(merkleRoot));
-        
+
         assertEq(strategy.getCampaignMerkleRoot(1), merkleRoot);
     }
 
@@ -81,17 +79,17 @@ contract AuthOrOwnerTest is AragonTest {
         vm.prank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Grant permission to testAlice
         vm.prank(address(createdDao));
         createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
-        
+
         // Alice should be able to call setAllocationCampaign
         bytes32 merkleRoot = keccak256("test-merkle-root");
-        
+
         vm.prank(testAlice);
         strategy.setAllocationCampaign(2, abi.encode(merkleRoot));
-        
+
         assertEq(strategy.getCampaignMerkleRoot(2), merkleRoot);
     }
 
@@ -100,17 +98,13 @@ contract AuthOrOwnerTest is AragonTest {
         vm.prank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Bob without permission should not be able to call
         bytes32 merkleRoot = keccak256("test-merkle-root");
-        
+
         vm.expectRevert(
             abi.encodeWithSelector(
-                DaoUnauthorized.selector, 
-                createdDao, 
-                address(strategy), 
-                testBob, 
-                STRATEGY_MANAGER_PERMISSION_ID
+                DaoUnauthorized.selector, createdDao, address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID
             )
         );
         vm.prank(testBob);
@@ -122,29 +116,27 @@ contract AuthOrOwnerTest is AragonTest {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         token.mint(address(createdDao), 10 ether);
-        
+
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
             "ipfs://metadata",
             CapitalDistributorPlugin.StrategyConfig(
-                toBytes32("merkle-strategy"), 
-                "", 
-                abi.encode(keccak256("initial-root"))
+                toBytes32("merkle-strategy"), "", abi.encode(keccak256("initial-root"))
             ),
             CapitalDistributorPlugin.PayoutConfig(token, bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(0, 0)
         );
-        
+
         // Pause campaign
         capitalDistributorPlugin.pauseCampaign(campaignId);
         vm.stopPrank();
-        
+
         // Owner updates merkle root
         bytes32 newRoot = keccak256("new-merkle-root");
         vm.prank(strategy.owner());
         strategy.updateCampaignMerkleRoot(campaignId, abi.encode(newRoot));
-        
+
         assertEq(strategy.getCampaignMerkleRoot(campaignId), newRoot);
     }
 
@@ -153,31 +145,29 @@ contract AuthOrOwnerTest is AragonTest {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         token.mint(address(createdDao), 10 ether);
-        
+
         uint256 campaignId = capitalDistributorPlugin.createCampaign(
             "ipfs://metadata",
             CapitalDistributorPlugin.StrategyConfig(
-                toBytes32("merkle-strategy"), 
-                "", 
-                abi.encode(keccak256("initial-root"))
+                toBytes32("merkle-strategy"), "", abi.encode(keccak256("initial-root"))
             ),
             CapitalDistributorPlugin.PayoutConfig(token, bytes32(0), ""),
             CapitalDistributorPlugin.CampaignSettings(0, 0)
         );
-        
+
         capitalDistributorPlugin.pauseCampaign(campaignId);
-        
+
         // Grant permission to charlie
         createdDao.grant(address(strategy), charlie, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         // Charlie updates merkle root
         bytes32 newRoot = keccak256("charlie-new-root");
         vm.prank(charlie);
         strategy.updateCampaignMerkleRoot(campaignId, abi.encode(newRoot));
-        
+
         assertEq(strategy.getCampaignMerkleRoot(campaignId), newRoot);
     }
 
@@ -185,12 +175,12 @@ contract AuthOrOwnerTest is AragonTest {
         vm.prank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         address initialOwner = strategy.owner();
-        
+
         vm.prank(initialOwner);
         strategy.renounceOwnership();
-        
+
         assertEq(strategy.owner(), address(0));
     }
 
@@ -198,15 +188,15 @@ contract AuthOrOwnerTest is AragonTest {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Grant permission to testAlice
         createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         // Now with the fix, testAlice can renounce ownership with permission
         vm.prank(testAlice);
         strategy.renounceOwnership();
-        
+
         assertEq(strategy.owner(), address(0));
     }
 
@@ -214,12 +204,12 @@ contract AuthOrOwnerTest is AragonTest {
         vm.prank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         address initialOwner = strategy.owner();
-        
+
         vm.prank(initialOwner);
         strategy.transferOwnership(testBob);
-        
+
         assertEq(strategy.owner(), testBob);
     }
 
@@ -227,20 +217,20 @@ contract AuthOrOwnerTest is AragonTest {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Grant permission to testAlice
         createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         // Now with the fix, testAlice can transfer ownership with permission
         vm.prank(testAlice);
         strategy.transferOwnership(charlie);
-        
+
         assertEq(strategy.owner(), charlie);
     }
 
     // =========================================================================
-    // VaultDepositPayoutActionEncoder authOrOwner Tests  
+    // VaultDepositPayoutActionEncoder authOrOwner Tests
     // =========================================================================
 
     function test_VaultEncoder_SetupCampaign_AsOwner() public {
@@ -248,12 +238,12 @@ contract AuthOrOwnerTest is AragonTest {
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-        
+
         address vault = makeAddr("vault");
-        
+
         vm.prank(encoder.owner());
         encoder.setupCampaign(1, abi.encode(vault));
-        
+
         assertEq(encoder.campaignVaults(1), vault);
     }
 
@@ -262,16 +252,16 @@ contract AuthOrOwnerTest is AragonTest {
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-        
+
         // Grant permission to testAlice
         createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         address vault = makeAddr("vault");
-        
+
         vm.prank(testAlice);
         encoder.setupCampaign(2, abi.encode(vault));
-        
+
         assertEq(encoder.campaignVaults(2), vault);
     }
 
@@ -280,16 +270,12 @@ contract AuthOrOwnerTest is AragonTest {
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-        
+
         address vault = makeAddr("vault");
-        
+
         vm.expectRevert(
             abi.encodeWithSelector(
-                DaoUnauthorized.selector,
-                createdDao,
-                address(encoder),
-                testBob,
-                ENCODER_MANAGER_PERMISSION_ID
+                DaoUnauthorized.selector, createdDao, address(encoder), testBob, ENCODER_MANAGER_PERMISSION_ID
             )
         );
         vm.prank(testBob);
@@ -301,12 +287,12 @@ contract AuthOrOwnerTest is AragonTest {
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-        
+
         address initialOwner = encoder.owner();
-        
+
         vm.prank(initialOwner);
         encoder.renounceOwnership();
-        
+
         assertEq(encoder.owner(), address(0));
     }
 
@@ -315,15 +301,15 @@ contract AuthOrOwnerTest is AragonTest {
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-        
+
         // Grant permission to testAlice
         createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         // Now with the fix, testAlice can renounce ownership with permission
         vm.prank(testAlice);
         encoder.renounceOwnership();
-        
+
         assertEq(encoder.owner(), address(0));
     }
 
@@ -332,12 +318,12 @@ contract AuthOrOwnerTest is AragonTest {
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-        
+
         address initialOwner = encoder.owner();
-        
+
         vm.prank(initialOwner);
         encoder.transferOwnership(testBob);
-        
+
         assertEq(encoder.owner(), testBob);
     }
 
@@ -346,15 +332,15 @@ contract AuthOrOwnerTest is AragonTest {
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-        
+
         // Grant permission to testAlice
         createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         // Now with the fix, testAlice can transfer ownership with permission
         vm.prank(testAlice);
         encoder.transferOwnership(charlie);
-        
+
         assertEq(encoder.owner(), charlie);
     }
 
@@ -367,16 +353,16 @@ contract AuthOrOwnerTest is AragonTest {
         vm.prank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Transfer ownership to testAlice
         vm.prank(strategy.owner());
         strategy.transferOwnership(testAlice);
-        
+
         // Alice as new owner can set allocation
         bytes32 merkleRoot = keccak256("testAlice-merkle-root");
         vm.prank(testAlice);
         strategy.setAllocationCampaign(10, abi.encode(merkleRoot));
-        
+
         assertEq(strategy.getCampaignMerkleRoot(10), merkleRoot);
     }
 
@@ -385,20 +371,20 @@ contract AuthOrOwnerTest is AragonTest {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Grant permission to testBob before renouncing
         createdDao.grant(address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         // Renounce ownership
         vm.prank(strategy.owner());
         strategy.renounceOwnership();
-        
+
         // Bob can still operate with permission even though there's no owner
         bytes32 merkleRoot = keccak256("testBob-merkle-root");
         vm.prank(testBob);
         strategy.setAllocationCampaign(20, abi.encode(merkleRoot));
-        
+
         assertEq(strategy.getCampaignMerkleRoot(20), merkleRoot);
         assertEq(strategy.owner(), address(0));
     }
@@ -408,29 +394,25 @@ contract AuthOrOwnerTest is AragonTest {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Grant permission to testAlice
         createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
-        
+
         // Alice can operate
         bytes32 merkleRoot1 = keccak256("testAlice-can-operate");
         vm.startPrank(testAlice);
         strategy.setAllocationCampaign(30, abi.encode(merkleRoot1));
         vm.stopPrank();
-        
+
         // Revoke permission
         vm.prank(address(createdDao));
         createdDao.revoke(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
-        
+
         // Alice cannot operate anymore
         bytes32 merkleRoot2 = keccak256("testAlice-cannot-operate");
         vm.expectRevert(
             abi.encodeWithSelector(
-                DaoUnauthorized.selector,
-                createdDao,
-                address(strategy),
-                testAlice,
-                STRATEGY_MANAGER_PERMISSION_ID
+                DaoUnauthorized.selector, createdDao, address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID
             )
         );
         vm.prank(testAlice);
@@ -442,21 +424,20 @@ contract AuthOrOwnerTest is AragonTest {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-        
+
         // Grant permission to both testAlice and testBob
         createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
         createdDao.grant(address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
-        
+
         // Both can operate
         vm.prank(testAlice);
         strategy.setAllocationCampaign(40, abi.encode(keccak256("testAlice-root")));
-        
+
         vm.prank(testBob);
         strategy.setAllocationCampaign(41, abi.encode(keccak256("testBob-root")));
-        
+
         assertEq(strategy.getCampaignMerkleRoot(40), keccak256("testAlice-root"));
         assertEq(strategy.getCampaignMerkleRoot(41), keccak256("testBob-root"));
     }
-
 }

--- a/tests/CapitalDistributorPluginTest.t.sol
+++ b/tests/CapitalDistributorPluginTest.t.sol
@@ -1377,13 +1377,13 @@ contract CapitalDistributorPluginTest is AragonTest {
         vm.stopPrank();
     }
 
-    /// @notice Test getCampaignstrategyId function
-    function test_GetCampaignstrategyId() public {
+    /// @notice Test getCampaignStrategyId function
+    function test_GetCampaignStrategyId() public {
         vm.startPrank(address(createdDao));
 
         uint256 campaignId = createBasicCampaign();
 
-        bytes32 strategyId = capitalDistributorPlugin.getCampaignstrategyId(campaignId);
+        bytes32 strategyId = capitalDistributorPlugin.getCampaignStrategyId(campaignId);
         assertEq(strategyId, toBytes32("mock-strategy"), "Strategy ID should match");
 
         vm.stopPrank();

--- a/tests/OwnerOrDaoTest.t.sol
+++ b/tests/OwnerOrDaoTest.t.sol
@@ -12,21 +12,14 @@ import { MerkleDistributorStrategy } from "../src/allocatorStrategies/MerkleDist
 import { VaultDepositPayoutActionEncoder } from "../src/payoutActionEncoders/VaultDepositPayoutActionEncoder.sol";
 import { AllocatorStrategyBase } from "../src/allocatorStrategies/AllocatorStrategyBase.sol";
 import { PayoutActionEncoderBase } from "../src/payoutActionEncoders/PayoutActionEncoderBase.sol";
-import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
+import { IAllocatorStrategy } from "../src/interfaces/IAllocatorStrategy.sol";
+import { IPayoutActionEncoder } from "../src/interfaces/IPayoutActionEncoder.sol";
 import { DAO } from "@aragon/osx/core/dao/DAO.sol";
 import { IPluginRepo } from "@aragon/osx/framework/plugin/repo/IPluginRepo.sol";
 
-contract AuthOrOwnerTest is AragonTest {
+contract OwnerOrDaoTest is AragonTest {
     MintableERC20 token;
     CapitalDistributorPlugin capitalDistributorPlugin;
-
-    address testAlice = makeAddr("testAlice");
-    address testBob = makeAddr("testBob");
-    address charlie = makeAddr("charlie");
-
-    bytes32 constant STRATEGY_MANAGER_PERMISSION_ID = keccak256("STRATEGY_MANAGER_PERMISSION");
-    bytes32 constant ENCODER_MANAGER_PERMISSION_ID = keccak256("ENCODER_MANAGER_PERMISSION");
-    bytes32 constant CAMPAIGN_MANAGER_PERMISSION_ID = keccak256("CAMPAIGN_MANAGER_PERMISSION");
 
     function setUp() public {
         // Deploy token
@@ -56,7 +49,7 @@ contract AuthOrOwnerTest is AragonTest {
     }
 
     // =========================================================================
-    // MerkleDistributorStrategy authOrOwner Tests
+    // MerkleDistributorStrategy OwnerOrDao Tests
     // =========================================================================
 
     function test_MerkleStrategy_SetAllocationCampaign_AsOwner() public {
@@ -74,20 +67,16 @@ contract AuthOrOwnerTest is AragonTest {
         assertEq(strategy.getCampaignMerkleRoot(1), merkleRoot);
     }
 
-    function test_MerkleStrategy_SetAllocationCampaign_WithPermission() public {
+    function test_MerkleStrategy_SetAllocationCampaign_AsDao() public {
         // Deploy strategy
         vm.prank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
 
-        // Grant permission to testAlice
-        vm.prank(address(createdDao));
-        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
-
-        // Alice should be able to call setAllocationCampaign
+        // DAO should be able to call setAllocationCampaign
         bytes32 merkleRoot = keccak256("test-merkle-root");
 
-        vm.prank(testAlice);
+        vm.prank(address(createdDao));
         strategy.setAllocationCampaign(2, abi.encode(merkleRoot));
 
         assertEq(strategy.getCampaignMerkleRoot(2), merkleRoot);
@@ -102,12 +91,8 @@ contract AuthOrOwnerTest is AragonTest {
         // Bob without permission should not be able to call
         bytes32 merkleRoot = keccak256("test-merkle-root");
 
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DaoUnauthorized.selector, createdDao, address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID
-            )
-        );
-        vm.prank(testBob);
+        vm.expectRevert(abi.encodeWithSelector(IAllocatorStrategy.NotAuthorized.selector, bob));
+        vm.prank(bob);
         strategy.setAllocationCampaign(3, abi.encode(merkleRoot));
     }
 
@@ -140,7 +125,7 @@ contract AuthOrOwnerTest is AragonTest {
         assertEq(strategy.getCampaignMerkleRoot(campaignId), newRoot);
     }
 
-    function test_MerkleStrategy_UpdateMerkleRoot_WithPermission() public {
+    function test_MerkleStrategy_UpdateMerkleRoot_AsDao() public {
         // Setup campaign
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
@@ -159,16 +144,12 @@ contract AuthOrOwnerTest is AragonTest {
 
         capitalDistributorPlugin.pauseCampaign(campaignId);
 
-        // Grant permission to charlie
-        createdDao.grant(address(strategy), charlie, STRATEGY_MANAGER_PERMISSION_ID);
-        vm.stopPrank();
-
-        // Charlie updates merkle root
-        bytes32 newRoot = keccak256("charlie-new-root");
-        vm.prank(charlie);
+        // DAO updates merkle root
+        bytes32 newRoot = keccak256("dao-new-root");
         strategy.updateCampaignMerkleRoot(campaignId, abi.encode(newRoot));
 
         assertEq(strategy.getCampaignMerkleRoot(campaignId), newRoot);
+        vm.stopPrank();
     }
 
     function test_MerkleStrategy_RenounceOwnership_AsOwner() public {
@@ -184,17 +165,14 @@ contract AuthOrOwnerTest is AragonTest {
         assertEq(strategy.owner(), address(0));
     }
 
-    function test_MerkleStrategy_RenounceOwnership_WithPermission() public {
+    function test_MerkleStrategy_RenounceOwnership_AsDao() public {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-
-        // Grant permission to testAlice
-        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
 
-        // Now with the fix, testAlice can renounce ownership with permission
-        vm.prank(testAlice);
+        // DAO can renounce ownership
+        vm.prank(address(createdDao));
         strategy.renounceOwnership();
 
         assertEq(strategy.owner(), address(0));
@@ -208,29 +186,26 @@ contract AuthOrOwnerTest is AragonTest {
         address initialOwner = strategy.owner();
 
         vm.prank(initialOwner);
-        strategy.transferOwnership(testBob);
+        strategy.transferOwnership(bob);
 
-        assertEq(strategy.owner(), testBob);
+        assertEq(strategy.owner(), bob);
     }
 
-    function test_MerkleStrategy_TransferOwnership_WithPermission() public {
+    function test_MerkleStrategy_TransferOwnership_AsDao() public {
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-
-        // Grant permission to testAlice
-        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
 
-        // Now with the fix, testAlice can transfer ownership with permission
-        vm.prank(testAlice);
-        strategy.transferOwnership(charlie);
+        // DAO can transfer ownership
+        vm.prank(address(createdDao));
+        strategy.transferOwnership(carol);
 
-        assertEq(strategy.owner(), charlie);
+        assertEq(strategy.owner(), carol);
     }
 
     // =========================================================================
-    // VaultDepositPayoutActionEncoder authOrOwner Tests
+    // VaultDepositPayoutActionEncoder OwnerOrDao Tests
     // =========================================================================
 
     function test_VaultEncoder_SetupCampaign_AsOwner() public {
@@ -247,19 +222,15 @@ contract AuthOrOwnerTest is AragonTest {
         assertEq(encoder.campaignVaults(1), vault);
     }
 
-    function test_VaultEncoder_SetupCampaign_WithPermission() public {
-        vm.startPrank(address(createdDao));
+    function test_VaultEncoder_SetupCampaign_AsDao() public {
+        vm.prank(address(createdDao));
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
 
-        // Grant permission to testAlice
-        createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
-        vm.stopPrank();
-
         address vault = makeAddr("vault");
 
-        vm.prank(testAlice);
+        vm.prank(address(createdDao));
         encoder.setupCampaign(2, abi.encode(vault));
 
         assertEq(encoder.campaignVaults(2), vault);
@@ -273,12 +244,8 @@ contract AuthOrOwnerTest is AragonTest {
 
         address vault = makeAddr("vault");
 
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DaoUnauthorized.selector, createdDao, address(encoder), testBob, ENCODER_MANAGER_PERMISSION_ID
-            )
-        );
-        vm.prank(testBob);
+        vm.expectRevert(abi.encodeWithSelector(IPayoutActionEncoder.NotAuthorized.selector, bob));
+        vm.prank(bob);
         encoder.setupCampaign(3, abi.encode(vault));
     }
 
@@ -296,18 +263,15 @@ contract AuthOrOwnerTest is AragonTest {
         assertEq(encoder.owner(), address(0));
     }
 
-    function test_VaultEncoder_RenounceOwnership_WithPermission() public {
+    function test_VaultEncoder_RenounceOwnership_AsDao() public {
         vm.startPrank(address(createdDao));
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-
-        // Grant permission to testAlice
-        createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
         vm.stopPrank();
 
-        // Now with the fix, testAlice can renounce ownership with permission
-        vm.prank(testAlice);
+        // DAO can renounce ownership
+        vm.prank(address(createdDao));
         encoder.renounceOwnership();
 
         assertEq(encoder.owner(), address(0));
@@ -322,26 +286,23 @@ contract AuthOrOwnerTest is AragonTest {
         address initialOwner = encoder.owner();
 
         vm.prank(initialOwner);
-        encoder.transferOwnership(testBob);
+        encoder.transferOwnership(bob);
 
-        assertEq(encoder.owner(), testBob);
+        assertEq(encoder.owner(), bob);
     }
 
-    function test_VaultEncoder_TransferOwnership_WithPermission() public {
+    function test_VaultEncoder_TransferOwnership_AsDao() public {
         vm.startPrank(address(createdDao));
         VaultDepositPayoutActionEncoder encoder = VaultDepositPayoutActionEncoder(
             address(capitalDistributorPlugin.deployActionEncoder(toBytes32("vault-encoder"), ""))
         );
-
-        // Grant permission to testAlice
-        createdDao.grant(address(encoder), testAlice, ENCODER_MANAGER_PERMISSION_ID);
         vm.stopPrank();
 
-        // Now with the fix, testAlice can transfer ownership with permission
-        vm.prank(testAlice);
-        encoder.transferOwnership(charlie);
+        // DAO can transfer ownership
+        vm.prank(address(createdDao));
+        encoder.transferOwnership(carol);
 
-        assertEq(encoder.owner(), charlie);
+        assertEq(encoder.owner(), carol);
     }
 
     // =========================================================================
@@ -354,90 +315,95 @@ contract AuthOrOwnerTest is AragonTest {
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
 
-        // Transfer ownership to testAlice
+        // Transfer ownership to alice
         vm.prank(strategy.owner());
-        strategy.transferOwnership(testAlice);
+        strategy.transferOwnership(alice);
 
         // Alice as new owner can set allocation
-        bytes32 merkleRoot = keccak256("testAlice-merkle-root");
-        vm.prank(testAlice);
+        bytes32 merkleRoot = keccak256("alice-merkle-root");
+        vm.prank(alice);
         strategy.setAllocationCampaign(10, abi.encode(merkleRoot));
 
         assertEq(strategy.getCampaignMerkleRoot(10), merkleRoot);
     }
 
-    function test_PermissionAfterOwnershipRenounced() public {
-        // Test that permission still works after ownership is renounced
+    function test_DaoCanOperateAfterOwnershipRenounced() public {
+        // Test that DAO can still operate after ownership is renounced
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-
-        // Grant permission to testBob before renouncing
-        createdDao.grant(address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
 
         // Renounce ownership
         vm.prank(strategy.owner());
         strategy.renounceOwnership();
 
-        // Bob can still operate with permission even though there's no owner
-        bytes32 merkleRoot = keccak256("testBob-merkle-root");
-        vm.prank(testBob);
+        // DAO can still operate even though there's no owner
+        bytes32 merkleRoot = keccak256("dao-merkle-root");
+        vm.prank(address(createdDao));
         strategy.setAllocationCampaign(20, abi.encode(merkleRoot));
 
         assertEq(strategy.getCampaignMerkleRoot(20), merkleRoot);
         assertEq(strategy.owner(), address(0));
     }
 
-    function test_RevokePermissionAfterGrant() public {
-        // Test revoking permissions
+    function test_OnlyOwnerOrDaoCanOperate() public {
+        // Test that only owner or DAO can operate, not other users
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-
-        // Grant permission to testAlice
-        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
-
-        // Alice can operate
-        bytes32 merkleRoot1 = keccak256("testAlice-can-operate");
-        vm.startPrank(testAlice);
-        strategy.setAllocationCampaign(30, abi.encode(merkleRoot1));
         vm.stopPrank();
 
-        // Revoke permission
-        vm.prank(address(createdDao));
-        createdDao.revoke(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
+        // Owner can operate
+        bytes32 merkleRoot1 = keccak256("owner-can-operate");
+        vm.prank(strategy.owner());
+        strategy.setAllocationCampaign(30, abi.encode(merkleRoot1));
+        assertEq(strategy.getCampaignMerkleRoot(30), merkleRoot1);
 
-        // Alice cannot operate anymore
-        bytes32 merkleRoot2 = keccak256("testAlice-cannot-operate");
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DaoUnauthorized.selector, createdDao, address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID
-            )
-        );
-        vm.prank(testAlice);
+        // DAO can operate
+        bytes32 merkleRoot2 = keccak256("dao-can-operate");
+        vm.prank(address(createdDao));
         strategy.setAllocationCampaign(31, abi.encode(merkleRoot2));
+        assertEq(strategy.getCampaignMerkleRoot(31), merkleRoot2);
+
+        // Regular users cannot operate
+        bytes32 merkleRoot3 = keccak256("alice-cannot-operate");
+        vm.expectRevert(abi.encodeWithSelector(IAllocatorStrategy.NotAuthorized.selector, alice));
+        vm.prank(alice);
+        strategy.setAllocationCampaign(32, abi.encode(merkleRoot3));
     }
 
-    function test_MultipleUsersWithPermission() public {
-        // Test multiple users with same permission
+    function test_OwnerTransferAndDaoAccess() public {
+        // Test owner transfer and DAO access remain independent
         vm.startPrank(address(createdDao));
         address strategyAddr = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
         MerkleDistributorStrategy strategy = MerkleDistributorStrategy(strategyAddr);
-
-        // Grant permission to both testAlice and testBob
-        createdDao.grant(address(strategy), testAlice, STRATEGY_MANAGER_PERMISSION_ID);
-        createdDao.grant(address(strategy), testBob, STRATEGY_MANAGER_PERMISSION_ID);
         vm.stopPrank();
 
-        // Both can operate
-        vm.prank(testAlice);
-        strategy.setAllocationCampaign(40, abi.encode(keccak256("testAlice-root")));
+        // Initial owner and DAO can both operate
+        address initialOwner = strategy.owner();
 
-        vm.prank(testBob);
-        strategy.setAllocationCampaign(41, abi.encode(keccak256("testBob-root")));
+        vm.prank(initialOwner);
+        strategy.setAllocationCampaign(40, abi.encode(keccak256("initial-owner-root")));
 
-        assertEq(strategy.getCampaignMerkleRoot(40), keccak256("testAlice-root"));
-        assertEq(strategy.getCampaignMerkleRoot(41), keccak256("testBob-root"));
+        vm.prank(address(createdDao));
+        strategy.setAllocationCampaign(41, abi.encode(keccak256("dao-root-1")));
+
+        // Transfer ownership to alice
+        vm.prank(initialOwner);
+        strategy.transferOwnership(alice);
+
+        // New owner (Alice) can operate
+        vm.prank(alice);
+        strategy.setAllocationCampaign(42, abi.encode(keccak256("alice-as-owner-root")));
+
+        // DAO can still operate after ownership transfer
+        vm.prank(address(createdDao));
+        strategy.setAllocationCampaign(43, abi.encode(keccak256("dao-root-2")));
+
+        // Initial owner can no longer operate
+        vm.expectRevert(abi.encodeWithSelector(IAllocatorStrategy.NotAuthorized.selector, initialOwner));
+        vm.prank(initialOwner);
+        strategy.setAllocationCampaign(44, abi.encode(keccak256("should-fail")));
     }
 }

--- a/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
+++ b/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
@@ -55,6 +55,13 @@ contract MerkleDistributorStrategyTest is AragonTest {
 
         // Set up mock-generated test data
         setupMockGeneratedData();
+
+        address strategyDeployment = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
+
+        createdDao.grant(strategyDeployment, address(createdDao), keccak256("STRATEGY_MANAGER_PERMISSION"));
+        createdDao.grant(
+            strategyDeployment, address(capitalDistributorPlugin), keccak256("STRATEGY_MANAGER_PERMISSION")
+        );
     }
 
     function setupMerkleTreeData() internal {
@@ -565,13 +572,10 @@ contract MerkleDistributorStrategyTest is AragonTest {
         bytes memory newRootData = abi.encode(newRoot);
 
         vm.expectRevert(abi.encodeWithSelector(MerkleDistributorStrategy.CampaignNotPaused.selector, campaignId));
-
-        // Call directly on strategy but from DAO context
-        vm.stopPrank();
-        vm.prank(address(createdDao));
         MerkleDistributorStrategy(address(campaign.allocationStrategy)).updateCampaignMerkleRoot(
             campaignId, newRootData
         );
+        vm.stopPrank();
     }
 
     function test_UpdateMerkleRootFailsOnActiveCampaign() public {

--- a/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
+++ b/tests/allocatorStrategies/MerkleDistributorStrategyTest.t.sol
@@ -55,13 +55,6 @@ contract MerkleDistributorStrategyTest is AragonTest {
 
         // Set up mock-generated test data
         setupMockGeneratedData();
-
-        address strategyDeployment = capitalDistributorPlugin.deployStrategy(toBytes32("merkle-strategy"), "");
-
-        createdDao.grant(strategyDeployment, address(createdDao), keccak256("STRATEGY_MANAGER_PERMISSION"));
-        createdDao.grant(
-            strategyDeployment, address(capitalDistributorPlugin), keccak256("STRATEGY_MANAGER_PERMISSION")
-        );
     }
 
     function setupMerkleTreeData() internal {

--- a/tests/factories/ActionEncoderFactoryTest.t.sol
+++ b/tests/factories/ActionEncoderFactoryTest.t.sol
@@ -200,7 +200,7 @@ contract ActionEncoderFactoryTest is Test {
         assertTrue(address(encoder1) != address(0));
 
         // Second deployment with same parameters should revert
-        bytes32 deploymentId = keccak256(abi.encode(VAULT_ENCODER_ID, address(dao), auxData));
+        bytes32 deploymentId = keccak256(abi.encode(VAULT_ENCODER_ID, address(dao), address(this), auxData));
         vm.expectRevert(
             abi.encodeWithSelector(FactoryBase.InstanceAlreadyDeployed.selector, deploymentId, address(encoder1))
         );
@@ -275,7 +275,8 @@ contract ActionEncoderFactoryTest is Test {
         bytes memory auxData = abi.encode(address(0x123));
 
         // Should not exist initially
-        (bool exists, IPayoutActionEncoder encoder) = factory.hasDeployment(VAULT_ENCODER_ID, dao, auxData);
+        (bool exists, IPayoutActionEncoder encoder) =
+            factory.hasDeployment(VAULT_ENCODER_ID, dao, address(this), auxData);
         assertFalse(exists);
         assertEq(address(encoder), address(0));
 
@@ -283,7 +284,7 @@ contract ActionEncoderFactoryTest is Test {
         IPayoutActionEncoder deployedEncoder = factory.deployActionEncoder(VAULT_ENCODER_ID, dao, auxData);
 
         // Should exist after deployment
-        (exists, encoder) = factory.hasDeployment(VAULT_ENCODER_ID, dao, auxData);
+        (exists, encoder) = factory.hasDeployment(VAULT_ENCODER_ID, dao, address(this), auxData);
         assertTrue(exists);
         assertEq(address(encoder), address(deployedEncoder));
     }
@@ -417,7 +418,7 @@ contract ActionEncoderFactoryTest is Test {
 
         // Instance exists check gas test
         gasStart = gasleft();
-        factory.hasDeployment(VAULT_ENCODER_ID, dao, auxData);
+        factory.hasDeployment(VAULT_ENCODER_ID, dao, address(this), auxData);
         gasUsed = gasStart - gasleft();
         console2.log("Gas used for hasDeployment:", gasUsed);
         assertTrue(gasUsed < 10_000);

--- a/tests/factories/AllocatorStrategyFactoryTest.t.sol
+++ b/tests/factories/AllocatorStrategyFactoryTest.t.sol
@@ -189,7 +189,7 @@ contract AllocatorStrategyFactoryTest is Test {
         assertTrue(strategy1 != address(0));
 
         // Second deployment with same parameters should revert
-        bytes32 deploymentId = keccak256(abi.encode(MERKLE_STRATEGY_ID, address(dao), auxData));
+        bytes32 deploymentId = keccak256(abi.encode(MERKLE_STRATEGY_ID, address(dao), address(this), auxData));
         vm.expectRevert(abi.encodeWithSelector(FactoryBase.InstanceAlreadyDeployed.selector, deploymentId, strategy1));
         factory.deployStrategy(MERKLE_STRATEGY_ID, dao, auxData);
     }
@@ -265,7 +265,7 @@ contract AllocatorStrategyFactoryTest is Test {
         bytes memory auxData = abi.encode(bytes32(keccak256("test-merkle-root")));
 
         // Should not exist initially
-        (bool exists, address strategy) = factory.hasDeployment(MERKLE_STRATEGY_ID, dao, auxData);
+        (bool exists, address strategy) = factory.hasDeployment(MERKLE_STRATEGY_ID, dao, address(this), auxData);
         assertFalse(exists);
         assertEq(strategy, address(0));
 
@@ -273,7 +273,7 @@ contract AllocatorStrategyFactoryTest is Test {
         address deployedStrategy = factory.deployStrategy(MERKLE_STRATEGY_ID, dao, auxData);
 
         // Should exist after deployment
-        (exists, strategy) = factory.hasDeployment(MERKLE_STRATEGY_ID, dao, auxData);
+        (exists, strategy) = factory.hasDeployment(MERKLE_STRATEGY_ID, dao, address(this), auxData);
         assertTrue(exists);
         assertEq(strategy, deployedStrategy);
     }
@@ -404,7 +404,7 @@ contract AllocatorStrategyFactoryTest is Test {
 
         // Instance exists check gas test
         gasStart = gasleft();
-        factory.hasDeployment(MERKLE_STRATEGY_ID, dao, auxData);
+        factory.hasDeployment(MERKLE_STRATEGY_ID, dao, address(this), auxData);
         gasUsed = gasStart - gasleft();
         console2.log("Gas used for hasDeployment:", gasUsed);
         assertTrue(gasUsed < 10_000);

--- a/tests/factories/FactoryBase.t.sol
+++ b/tests/factories/FactoryBase.t.sol
@@ -163,25 +163,25 @@ contract FactoryBaseTest is Test {
         bytes memory auxData1 = abi.encode(1, 2, 3);
         bytes memory auxData2 = abi.encode(4, 5, 6);
 
-        bytes32 hash1 = factory.exposedComputeParamsHash(TYPE_ID_1, IDAO(address(dao)), auxData1);
-        bytes32 hash2 = factory.exposedComputeParamsHash(TYPE_ID_1, IDAO(address(dao)), auxData2);
-        bytes32 hash3 = factory.exposedComputeParamsHash(TYPE_ID_2, IDAO(address(dao)), auxData1);
+        bytes32 hash1 = factory.exposedComputeParamsHash(TYPE_ID_1, IDAO(address(dao)), address(this), auxData1);
+        bytes32 hash2 = factory.exposedComputeParamsHash(TYPE_ID_1, IDAO(address(dao)), address(this), auxData2);
+        bytes32 hash3 = factory.exposedComputeParamsHash(TYPE_ID_2, IDAO(address(dao)), address(this), auxData1);
 
         assertTrue(hash1 != hash2);
         assertTrue(hash1 != hash3);
         assertTrue(hash2 != hash3);
 
-        bytes32 expectedHash = keccak256(abi.encode(TYPE_ID_1, address(dao), auxData1));
+        bytes32 expectedHash = keccak256(abi.encode(TYPE_ID_1, address(dao), address(this), auxData1));
         assertEq(hash1, expectedHash);
     }
 
     /// @notice Test hash collision resistance
     function test_HashCollisionResistance() public view {
         bytes memory auxData1 = abi.encodePacked(TYPE_ID_1, address(dao));
-        bytes32 hash1 = factory.exposedComputeParamsHash(TYPE_ID_2, IDAO(address(0)), auxData1);
+        bytes32 hash1 = factory.exposedComputeParamsHash(TYPE_ID_2, IDAO(address(0)), address(this), auxData1);
 
         bytes memory auxData2 = "";
-        bytes32 hash2 = factory.exposedComputeParamsHash(TYPE_ID_1, IDAO(address(dao)), auxData2);
+        bytes32 hash2 = factory.exposedComputeParamsHash(TYPE_ID_1, IDAO(address(dao)), address(this), auxData2);
 
         assertTrue(hash1 != hash2);
     }
@@ -250,10 +250,10 @@ contract FactoryBaseTest is Test {
     function testFuzz_HashComputation(bytes32 typeId, address daoAddr, bytes memory auxData) public view {
         IDAO daoInterface = IDAO(daoAddr);
 
-        bytes32 extendedHash = factory.exposedComputeParamsHash(typeId, daoInterface, auxData);
+        bytes32 extendedHash = factory.exposedComputeParamsHash(typeId, daoInterface, address(this), auxData);
 
         if (auxData.length == 0) {
-            assertEq(extendedHash, keccak256(abi.encode(typeId, daoAddr, auxData)));
+            assertEq(extendedHash, keccak256(abi.encode(typeId, daoAddr, address(this), auxData)));
         }
     }
 
@@ -316,13 +316,14 @@ contract ConcreteFactoryBase is FactoryBase {
     function exposedComputeParamsHash(
         bytes32 _typeId,
         IDAO _dao,
+        address _plugin,
         bytes memory _auxData
     )
         external
         pure
         returns (bytes32)
     {
-        return _computeDeploymentId(_typeId, _dao, _auxData);
+        return _computeDeploymentId(_typeId, _dao, _plugin, _auxData);
     }
 }
 

--- a/tests/payoutActionEncoders/VaultDepositPayoutActionEncoderTest.t.sol
+++ b/tests/payoutActionEncoders/VaultDepositPayoutActionEncoderTest.t.sol
@@ -91,11 +91,7 @@ contract VaultDepositPayoutActionEncoderTest is AragonTest {
         address newVault = makeAddr("newVault");
 
         vm.prank(testAlice);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPayoutActionEncoder.NotAuthorized.selector, testAlice
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IPayoutActionEncoder.NotAuthorized.selector, testAlice));
         encoder.setupCampaign(CAMPAIGN_ID, abi.encode(newVault));
     }
 

--- a/tests/payoutActionEncoders/VaultDepositPayoutActionEncoderTest.t.sol
+++ b/tests/payoutActionEncoders/VaultDepositPayoutActionEncoderTest.t.sol
@@ -8,6 +8,7 @@ import { ActionEncoderFactory } from "../../src/factories/ActionEncoderFactory.s
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { IDAO } from "@aragon/commons/dao/IDAO.sol";
 import { Action } from "@aragon/commons/executors/IExecutor.sol";
+import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
 
 import { DAO } from "@aragon/osx/core/dao/DAO.sol";
 import { AragonTest } from "../helpers/AragonTest.sol";
@@ -89,7 +90,11 @@ contract VaultDepositPayoutActionEncoderTest is AragonTest {
         address newVault = makeAddr("newVault");
 
         vm.prank(testAlice);
-        vm.expectRevert(abi.encodeWithSelector(VaultDepositPayoutActionEncoder.OnlyOwner.selector, testAlice));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DaoUnauthorized.selector, createdDao, encoder, testAlice, keccak256("ENCODER_MANAGER_PERMISSION")
+            )
+        );
         encoder.setupCampaign(CAMPAIGN_ID, abi.encode(newVault));
     }
 

--- a/tests/payoutActionEncoders/VaultDepositPayoutActionEncoderTest.t.sol
+++ b/tests/payoutActionEncoders/VaultDepositPayoutActionEncoderTest.t.sol
@@ -9,6 +9,7 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { IDAO } from "@aragon/commons/dao/IDAO.sol";
 import { Action } from "@aragon/commons/executors/IExecutor.sol";
 import { DaoUnauthorized } from "@aragon/commons/permission/auth/auth.sol";
+import { IPayoutActionEncoder } from "../../src/interfaces/IPayoutActionEncoder.sol";
 
 import { DAO } from "@aragon/osx/core/dao/DAO.sol";
 import { AragonTest } from "../helpers/AragonTest.sol";
@@ -92,7 +93,7 @@ contract VaultDepositPayoutActionEncoderTest is AragonTest {
         vm.prank(testAlice);
         vm.expectRevert(
             abi.encodeWithSelector(
-                DaoUnauthorized.selector, createdDao, encoder, testAlice, keccak256("ENCODER_MANAGER_PERMISSION")
+                IPayoutActionEncoder.NotAuthorized.selector, testAlice
             )
         );
         encoder.setupCampaign(CAMPAIGN_ID, abi.encode(newVault));


### PR DESCRIPTION
Main Changes:

  1. Added ownership/DAO authorization pattern (authOrOwner)
    - Introduced ownerOrDao modifier
    - Both AllocatorStrategyBase and PayoutActionEncoderBase now support dual authorization (owner OR DAO)
  2. Added deployment helper methods to the plugin
    - deployStrategy() and deployActionEncoder() methods in CapitalDistributorPlugin
  3. Refactored factory deployment logic
    - Factories now use the plugin address to compute deployment IDs